### PR TITLE
Record architecture decisions in ADR format

### DIFF
--- a/.adr-dir
+++ b/.adr-dir
@@ -1,0 +1,1 @@
+doc/architecture/decisions

--- a/doc/architecture/decisions/0001-record-architecture-decisions.md
+++ b/doc/architecture/decisions/0001-record-architecture-decisions.md
@@ -1,0 +1,19 @@
+# 1. Record architecture decisions
+
+Date: 2024-09-04
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).


### PR DESCRIPTION
As described in the [Playbook](https://playbook.dxw.com/tech/how-we-do-development/#tracking-changes), we use Architecture Decision Records (ADRs) to capture the architectural decisions made on our projects. This PR codifies the process for this project.