### PR TITLE
Correct total repos count

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,14 +19,15 @@ const httpServer = createServer(async (request, response) => {
   // "Only on this account" when registering the app.
 
   const installations = [];
-  await OctokitApp.app.eachInstallation(async octokit => {
+  await OctokitApp.app.eachInstallation(async (octokit) => {
     const name = octokit.installation.account.login;
-    
-    const repos = await getReposForInstallation(octokit);
+
+    const { repos, totalRepos } = await getReposForInstallation(octokit);
 
     installations.push({
       name,
       repos,
+      totalRepos,
     });
   });
 
@@ -39,9 +40,12 @@ const getReposForInstallation = async ({ octokit, installation }) => {
   return octokit
     .request(installation.repositories_url)
     .then(({ data }) => {
-      return data.repositories.map((repo) => ({
+      const repos = data.repositories.map((repo) => ({
         name: repo.name,
       }));
+      const totalRepos = data.total_count;
+
+      return { repos, totalRepos };
     })
     .catch((error) => {
       console.error(error);

--- a/index.njk
+++ b/index.njk
@@ -19,10 +19,10 @@
       <div class="bg-stone-50 overflow-hidden rounded-lg border-b-4 border-stone-200 space-y-4">
         <h2 class="bg-white border-b-2 border-stone-100 text-xl font-bold p-4">{{ name }}</h2>
         <p class="mx-4">
-          {% if repos.length === 1 %}
+          {% if totalRepos === 1 %}
           There is <span class="font-bold">1</span> repository
           {% else %} 
-          There are <span class="font-bold">{{ repos.length }}</span> repositories
+          There are <span class="font-bold">{{ totalRepos }}</span> repositories
           {% endif %}
           that Towtruck is tracking for <span class="font-bold">{{ name }}</span>.
         </p>


### PR DESCRIPTION
We were using the length of the array of repos returned from the API but this is paginated so would show only a maximum of 30 (without futher configuration). Now we use the 'total_count' returned from the API which is the total number of repos in the organisation.