### PR TITLE
Fix fetching dependencies

### DIFF
--- a/renovate/dependencyDashboard.js
+++ b/renovate/dependencyDashboard.js
@@ -52,9 +52,7 @@ export const handleIssuesApiResponse = (response) => {
 
   return parseDependenciesFromDashboard(dependencyDashboardIssue);
 }
+export const getDependenciesForRepo = ({ octokit, repository }) => {
+  return octokit.request(repository.issues_url).then(handleIssuesApiResponse);
+};
 
-export const getDependenciesForRepo = ({ octokit }, repo) => {
-  return octokit
-    .request(repo.issues_url)
-    .then(handleIssuesApiResponse);
-}

--- a/utils.js
+++ b/utils.js
@@ -31,4 +31,5 @@ export const mapRepoFromApiForStorage = (repo) => ({
   language: repo.language,
   topics: repo.topics,
   openIssues: repo.open_issues,
+  dependencies: repo.dependencies,
 });

--- a/utils.test.js
+++ b/utils.test.js
@@ -89,6 +89,23 @@ describe("mapRepoFromStorageToUi", () => {
 
   describe("mapRepo", () => {
     it("maps the repo from the data returned from the api", async () => {
+      const repoDependencies = [
+        {
+          user: {
+            login: "some-user",
+          },
+          pull_request: {},
+          body: "Here's a pull request to manually update dependency `foo-utils 1.2.3` to `foo-utils 1.2.4`.",
+        },
+        {
+          user: {
+            login: "renovate[bot]",
+          },
+          pull_request: {},
+          body: "Configure Renovate",
+        },
+      ];
+
       const apiRepo = {
         id: 248204237,
         node_id: "MDEwOlJlcG9zaXRvcnkyNDgyMDQyMzc=",
@@ -235,6 +252,7 @@ describe("mapRepoFromStorageToUi", () => {
           triage: false,
           pull: false,
         },
+        dependencies: repoDependencies,
       };
 
       const repoToSave = {
@@ -251,6 +269,7 @@ describe("mapRepoFromStorageToUi", () => {
         language: "Ruby",
         topics: ["delivery-plus", "internal", "tech-ops"],
         openIssues: 2,
+        dependencies: repoDependencies,
       };
 
       expect.deepEqual(mapRepoFromApiForStorage(apiRepo), repoToSave);


### PR DESCRIPTION
I broke this with #27.
I switched from passing repos as a second parameter to passing it as part of the object in the first parameter in the consuming function but not in the function signature itself.
This format follows the signature the Octokit builtin functions use so I think it makes sense to align our approach with theirs.