### PR TITLE
Fix dependency parsing from Renovate dependency dashboard

### DIFF
--- a/utils/renovate/dependencyDashboard.test.js
+++ b/utils/renovate/dependencyDashboard.test.js
@@ -24,7 +24,17 @@ describe("handleIssuesApiResponse", () => {
           user: {
             login: "renovate[bot]",
           },
-          body: '# Dependency Dashboard\nList of dependencies:\n- `libquux v4.1.1.rc4`\n- `@xyzzy/utils "~> 22.04 Questing Quokka"`\n\nHere\'s some more:\n- `baz-framework ^0.1`',
+          body: '# Dependency Dashboard\n'
+            + 'Here\'s some things in the preamble that should not be picked up:\n'
+            + '`fake-dependency`, `another-fake-dependency`\n'
+            + '\n'
+            + '## Detected dependencies\n'
+            + '- `libquux v4.1.1.rc4`\n'
+            + '- `@xyzzy/utils "~> 22.04 Questing Quokka"`\n'
+            + '\n'
+            + 'Here\'s some more:\n'
+            + '- `baz-framework ^0.1`\n'
+            + '---',
         },
       ],
     };


### PR DESCRIPTION
This changes the parsing to only process lines between the 'Detected dependencies' header and the next horizontal rule, which fixes an issue where dependency references in previous sections of the dashboard were being parsed incorrectly and sometimes causing weird results.

Example of incorrect parsing (from the [nest-template repo's dashboard](https://github.com/dxw/nest-template/issues/30)):
<img width="469" alt="image" src="https://github.com/user-attachments/assets/34ed71c8-e004-4a85-bfda-16f8e3565a13">

Example of fixed parsing (note that Node is listed in the dashboard with two different versions as `Dockerfile` and `.node-version` disagree):
<img width="470" alt="image" src="https://github.com/user-attachments/assets/8a55ac56-13d6-49c8-a453-a7ed80874208">
