### PR TITLE
Sort by open PRs, Issues and Updated At

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,8 +15,7 @@ const httpServer = createServer(async (request, response) => {
     return response.end();
   }
 
-  const pathToRepos = "./data/repos.json";
-  const persistedData = await getReposFromJson(pathToRepos);
+  const persistedData = await getReposFromJson("./data/repos.json");
 
   const template = nunjucks.render(
     "index.njk",

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ import { createServer } from "http";
 import nunjucks from "nunjucks";
 import { getReposFromJson, mapRepoFromStorageToUi } from "./utils/index.js";
 import { getQueryParams } from "./utils/queryParams.js";
+import { sortByOpenPrs } from "./utils/sorting.js";
 
 nunjucks.configure({
   autoescape: true,
@@ -17,13 +18,15 @@ const httpServer = createServer(async (request, response) => {
   }
 
   const persistedData = await getReposFromJson("./data/repos.json");
+  const reposForUi = mapRepoFromStorageToUi(persistedData);
 
   const { sortDirection, sortBy } = getQueryParams(url);
 
   const template = nunjucks.render("index.njk", {
     sortBy,
     sortDirection,
-    ...mapRepoFromStorageToUi(persistedData),
+    ...reposForUi,
+    repos: sortByOpenPrs(reposForUi.repos, sortDirection),
   });
 
   return response.end(template);

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 import { createServer } from "http";
 import nunjucks from "nunjucks";
 import { getReposFromJson, mapRepoFromStorageToUi } from "./utils/index.js";
+import { getQueryParams } from "./utils/queryParams.js";
 
 nunjucks.configure({
   autoescape: true,
@@ -17,10 +18,13 @@ const httpServer = createServer(async (request, response) => {
 
   const persistedData = await getReposFromJson("./data/repos.json");
 
-  const template = nunjucks.render(
-    "index.njk",
-    mapRepoFromStorageToUi(persistedData)
-  );
+  const { sortDirection, sortBy } = getQueryParams(url);
+
+  const template = nunjucks.render("index.njk", {
+    sortBy,
+    sortDirection,
+    ...mapRepoFromStorageToUi(persistedData),
+  });
 
   return response.end(template);
 });

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ import { createServer } from "http";
 import nunjucks from "nunjucks";
 import { getReposFromJson, mapRepoFromStorageToUi } from "./utils/index.js";
 import { getQueryParams } from "./utils/queryParams.js";
-import { sortByOpenPrs } from "./utils/sorting.js";
+import { sortByType } from "./utils/sorting.js";
 
 nunjucks.configure({
   autoescape: true,
@@ -26,7 +26,7 @@ const httpServer = createServer(async (request, response) => {
     sortBy,
     sortDirection,
     ...reposForUi,
-    repos: sortByOpenPrs(reposForUi.repos, sortDirection),
+    repos: sortByType(reposForUi.repos, sortDirection, sortBy),
   });
 
   return response.end(template);

--- a/index.njk
+++ b/index.njk
@@ -1,3 +1,5 @@
+{% import "./macros.njk" as macros %}
+
 <!DOCTYPE html>
 <html>
   <head>
@@ -35,7 +37,7 @@
                 <th class="py-2 pl-2" scope="col">Language</th>
                 <th class="py-2 pl-2" scope="col">Topics</th>
                 <th class="py-2 pl-2" scope="col">Open issues count</th>
-                <th class="py-2 pl-2" scope="col">Open PRs count</th>
+                {{macros.sortableTableHeader("Open PRs count", "openPrsCount", sortDirection, sortBy)}}
                 <th class="py-2 pl-2 last:pr-2" scope="col">Last updated</th>
                 <th class="py-2 pl-2 last:pr-2" scope="col">Dependencies</th>
               </tr>

--- a/index.njk
+++ b/index.njk
@@ -36,7 +36,7 @@
                 <th class="py-2 pl-2" scope="col">Description</th>
                 <th class="py-2 pl-2" scope="col">Language</th>
                 <th class="py-2 pl-2" scope="col">Topics</th>
-                <th class="py-2 pl-2" scope="col">Open issues count</th>
+                {{macros.sortableTableHeader("Open issues count", "openIssues", sortDirection, sortBy)}}
                 {{macros.sortableTableHeader("Open PRs count", "openPrsCount", sortDirection, sortBy)}}
                 <th class="py-2 pl-2 last:pr-2" scope="col">Last updated</th>
                 <th class="py-2 pl-2 last:pr-2" scope="col">Dependencies</th>

--- a/index.njk
+++ b/index.njk
@@ -43,7 +43,7 @@
             <tbody>
               {% for repo in repos %}
               <tr class="even:bg-white">
-                 <td class="py-2 pl-2"><a target="_blank" class="text-blue-600 dark:text-blue-500 hover:underline" href="{{repo.url}}">{{ repo.name }}</a></td>
+                 <td class="py-2 pl-2"><a target="_blank" class="text-blue-600 dark:text-blue-500 hover:underline" href="{{repo.htmlUrl}}">{{ repo.name }}</a></td>
                 <td class="py-2 pl-2">{{ repo.description }}</td>
                 <td class="py-2 pl-2">{{ repo.language }}</td>
                 <td class="py-2 pl-2">{{ repo.topics | join(", ")}}</td>

--- a/index.njk
+++ b/index.njk
@@ -38,7 +38,7 @@
                 <th class="py-2 pl-2" scope="col">Topics</th>
                 {{macros.sortableTableHeader("Open issues count", "openIssues", sortDirection, sortBy)}}
                 {{macros.sortableTableHeader("Open PRs count", "openPrsCount", sortDirection, sortBy)}}
-                <th class="py-2 pl-2 last:pr-2" scope="col">Last updated</th>
+                {{macros.sortableTableHeader("Updated at", "updatedAt", sortDirection, sortBy)}}
                 <th class="py-2 pl-2 last:pr-2" scope="col">Dependencies</th>
               </tr>
             </thead>

--- a/macros.njk
+++ b/macros.njk
@@ -1,0 +1,40 @@
+{% macro sortableTableHeader(name, id, sortDirection, sortBy) %}
+
+{% set upArrow %}
+    <svg class="inline-block h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+{%endset%}
+
+{% set downArrow %}
+    <svg class="inline-block h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7"></path>
+    </svg>
+{%endset%}
+    
+    
+
+{% set sortingOnThisParam = id === sortBy %}
+{% set linkParams = "?sortBy=" + id + "&sortDirection=asc" %}
+
+{%if sortingOnThisParam and sortDirection === "asc"%}
+    {% set linkParams = "?sortBy=" + id + "&sortDirection=desc" %}
+{%endif%}
+
+<th class="py-2 pl-2" scope="col"><a href="/{{linkParams}}"> {{name}}
+
+    <span class="text-xs ml-1">
+        {% if sortDirection === "asc" and sortingOnThisParam %}
+            {{upArrow | safe}}
+        {% elseif sortDirection === 'desc' and sortingOnThisParam %}
+            {{downArrow | safe}}
+        {% elseif id !== sortBy %}
+        <div class="w-full">
+            {{upArrow | safe}}
+            {{downArrow | safe}}
+        </div>
+        {% endif %}
+    </span>
+</a>
+</th>
+{% endmacro %}

--- a/utils/index.js
+++ b/utils/index.js
@@ -25,6 +25,7 @@ export const mapRepoFromStorageToUi = (persistedData) => {
     return {
       ...repo,
       updatedAt: newDate,
+      updatedAtISO8601: repo.updatedAt,
     };
   });
 
@@ -77,6 +78,7 @@ export const getReposFromJson = async (filePath) => {
 /**
  * @typedef {StoredRepo} UiRepo
  * @property {Date} date - The date the repo was last updated in JS date format.
+ * @property {string} updatedAtISO8601 - The date the repo was last updated in ISO8601 format for sorting.
  */
 
 /**

--- a/utils/index.js
+++ b/utils/index.js
@@ -10,6 +10,8 @@ import { readFile } from "fs/promises";
 /**
  * @typedef {PersistedData} RepoData
  * @property {UiRepo[]} repos - An array of repos.
+ * @property {number} totalRepos - The total number of repos.
+ * @property {string} org - The name of the Github organisation the repos belong to.
  */
 
 /**

--- a/utils/index.test.js
+++ b/utils/index.test.js
@@ -28,6 +28,7 @@ describe("mapRepoFromStorageToUi", () => {
         name: "repo1",
         description: "description1",
         updatedAt: new Date("2021-01-01T00:00:00Z").toLocaleDateString(),
+        updatedAtISO8601: "2021-01-01T00:00:00Z",
         htmlUrl: "http://url.com/repo1",
         apiUrl: "http://api.com/repo1",
         pullsUrl: "http://api.com/repo1/pulls",

--- a/utils/queryParams.js
+++ b/utils/queryParams.js
@@ -1,0 +1,12 @@
+/**
+ * Returns the sortDirection and sortBy query parameters from the request
+ * @param {URL} url
+ * @returns {Object} - Object containing the sortDirection and sortBy query parameters, they will be null if they aren't present
+ */
+export const getQueryParams = (url) => {
+  const [sortBy, sortDirection] = ["sortBy", "sortDirection"].map((param) => {
+    return url.searchParams.get(param);
+  });
+
+  return { sortBy, sortDirection };
+};

--- a/utils/queryParams.test.js
+++ b/utils/queryParams.test.js
@@ -1,0 +1,39 @@
+import { describe, it } from "node:test";
+import expect from "node:assert";
+import { getQueryParams } from "./queryParams.js";
+
+describe("getQueryParams", () => {
+  it("returns null if there are no query params", () => {
+    const url = new URL("http://localhost:3000");
+
+    const result = getQueryParams(url);
+
+    expect.deepEqual(result, { sortBy: null, sortDirection: null });
+  });
+
+  it("returns sortDirection param if it exists", () => {
+    const url = new URL("http://localhost:3000?sortDirection=asc");
+
+    const result = getQueryParams(url);
+
+    expect.deepEqual(result, { sortBy: null, sortDirection: "asc" });
+  });
+
+  it("returns sortBy param if it exists", () => {
+    const url = new URL("http://localhost:3000?sortBy=openPrs");
+
+    const result = getQueryParams(url);
+
+    expect.deepEqual(result, { sortBy: "openPrs", sortDirection: null });
+  });
+
+  it("returns both params if they exists", () => {
+    const url = new URL(
+      "http://localhost:3000?sortBy=openPrs&sortDirection=asc"
+    );
+
+    const result = getQueryParams(url);
+
+    expect.deepEqual(result, { sortBy: "openPrs", sortDirection: "asc" });
+  });
+});

--- a/utils/sorting.js
+++ b/utils/sorting.js
@@ -6,20 +6,6 @@
  */
 
 /**
- * Sorts repos by the number of open PRs
- * @param {UiRepo[]} repos
- * @param {SortDirection} sortDirection
- * @returns {UiRepo[]}
- */
-export const sortByOpenPrs = (repos, sortDirection) => {
-  if (!sortDirection) return repos;
-  if (sortDirection === "asc") {
-    return repos.sort((a, b) => a.openPrsCount - b.openPrsCount);
-  }
-  return repos.sort((a, b) => b.openPrsCount - a.openPrsCount);
-};
-
-/**
  * Sorts repos by the a numeric value
  * @param {UiRepo[]} repos
  * @param {SortDirection} sortDirection

--- a/utils/sorting.js
+++ b/utils/sorting.js
@@ -33,3 +33,22 @@ export const sortByNumericValue = (repos, sortDirection, key) => {
   }
   return repos.sort((a, b) => b[key] - a[key]);
 };
+
+/**
+ * Sorts repositories based on the specified type and direction.
+ * @param {"openPrsCount"|"openIssues"} sortBy - The type of sorting to apply, either by open PRs count or open issues.
+ * @param {SortDirection} sortDirection - The direction to sort, either "asc" for ascending or "desc" for descending.
+ * @param {UiRepo[]} repos - An array of repository objects to sort.
+ * @returns {UiRepo[]} The sorted array of repository objects.
+ */
+export const sortByType = (repos, sortDirection, sortBy) => {
+  switch (sortBy) {
+    case "openPrsCount":
+      return sortByNumericValue(repos, sortDirection, "openPrsCount");
+
+    case "openIssues":
+      return sortByNumericValue(repos, sortDirection, "openIssues");
+    default:
+      return repos;
+  }
+};

--- a/utils/sorting.js
+++ b/utils/sorting.js
@@ -1,0 +1,20 @@
+/**
+ * @typedef {string} SortDirection
+ * @enum {SortDirection}
+ * @property {"asc"} ASC
+ * @property {"desc"} DESC
+ */
+
+/**
+ * Sorts repos by the number of open PRs
+ * @param {UiRepo[]} repos
+ * @param {SortDirection} sortDirection
+ * @returns {UiRepo[]}
+ */
+export const sortByOpenPrs = (repos, sortDirection) => {
+  if (!sortDirection) return repos;
+  if (sortDirection === "asc") {
+    return repos.sort((a, b) => a.openPrsCount - b.openPrsCount);
+  }
+  return repos.sort((a, b) => b.openPrsCount - a.openPrsCount);
+};

--- a/utils/sorting.js
+++ b/utils/sorting.js
@@ -21,6 +21,25 @@ export const sortByNumericValue = (repos, sortDirection, key) => {
 };
 
 /**
+ * Sorts repositories by the date they were last updated
+ * @param {UiRepo[]} repos
+ * @param {SortDirection} sortDirection
+ * @returns {UiRepo[]}
+ */
+export const sortByUpdatedAt = (repos, sortDirection) => {
+  if (!sortDirection) return repos;
+
+  if (sortDirection === "asc") {
+    return repos.sort((a, b) => {
+      return a.updatedAtISO8601.localeCompare(b.updatedAtISO8601);
+    });
+  }
+  return repos.sort((a, b) =>
+    b.updatedAtISO8601.localeCompare(a.updatedAtISO8601)
+  );
+};
+
+/**
  * Sorts repositories based on the specified type and direction.
  * @param {"openPrsCount"|"openIssues"} sortBy - The type of sorting to apply, either by open PRs count or open issues.
  * @param {SortDirection} sortDirection - The direction to sort, either "asc" for ascending or "desc" for descending.
@@ -34,6 +53,9 @@ export const sortByType = (repos, sortDirection, sortBy) => {
 
     case "openIssues":
       return sortByNumericValue(repos, sortDirection, "openIssues");
+
+    case "updatedAt":
+      return sortByUpdatedAt(repos, sortDirection);
     default:
       return repos;
   }

--- a/utils/sorting.js
+++ b/utils/sorting.js
@@ -18,3 +18,18 @@ export const sortByOpenPrs = (repos, sortDirection) => {
   }
   return repos.sort((a, b) => b.openPrsCount - a.openPrsCount);
 };
+
+/**
+ * Sorts repos by the a numeric value
+ * @param {UiRepo[]} repos
+ * @param {SortDirection} sortDirection
+ * @param {string} key - The key to sort by
+ * @returns {UiRepo[]}
+ */
+export const sortByNumericValue = (repos, sortDirection, key) => {
+  if (!sortDirection) return repos;
+  if (sortDirection === "asc") {
+    return repos.sort((a, b) => a[key] - b[key]);
+  }
+  return repos.sort((a, b) => b[key] - a[key]);
+};

--- a/utils/sorting.test.js
+++ b/utils/sorting.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import expect from "node:assert";
-import { sortByOpenPrs } from "./sorting.js";
+import { sortByOpenPrs, sortByNumericValue } from "./sorting.js";
 
 describe("sortByOpenPrs", () => {
   it("returns the original array if sortDirection is not provided", () => {
@@ -44,6 +44,52 @@ describe("sortByOpenPrs", () => {
       { name: "Repo 3", openPrsCount: 7 },
       { name: "Repo 1", openPrsCount: 5 },
       { name: "Repo 2", openPrsCount: 3 },
+    ]);
+  });
+});
+
+describe("sortByNumericValue", () => {
+  it("returns the original array if sortDirection is not provided", () => {
+    const repos = [
+      { name: "Repo 1", value: 5 },
+      { name: "Repo 2", value: 3 },
+      { name: "Repo 3", value: 7 },
+    ];
+
+    const result = sortByNumericValue(repos, null, "value");
+
+    expect.deepEqual(result, repos);
+  });
+
+  it("sorts the array in ascending order by the specified key if sortDirection is 'asc'", () => {
+    const repos = [
+      { name: "Repo 1", value: 5 },
+      { name: "Repo 2", value: 3 },
+      { name: "Repo 3", value: 7 },
+    ];
+
+    const result = sortByNumericValue(repos, "asc", "value");
+
+    expect.deepEqual(result, [
+      { name: "Repo 2", value: 3 },
+      { name: "Repo 1", value: 5 },
+      { name: "Repo 3", value: 7 },
+    ]);
+  });
+
+  it("sorts the array in descending order by the specified key if sortDirection is 'desc'", () => {
+    const repos = [
+      { name: "Repo 1", value: 5 },
+      { name: "Repo 2", value: 3 },
+      { name: "Repo 3", value: 7 },
+    ];
+
+    const result = sortByNumericValue(repos, "desc", "value");
+
+    expect.deepEqual(result, [
+      { name: "Repo 3", value: 7 },
+      { name: "Repo 1", value: 5 },
+      { name: "Repo 2", value: 3 },
     ]);
   });
 });

--- a/utils/sorting.test.js
+++ b/utils/sorting.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import expect from "node:assert";
-import { sortByNumericValue, sortByType } from "./sorting.js";
+import { sortByNumericValue, sortByType, sortByUpdatedAt } from "./sorting.js";
 
 describe("sortByNumericValue", () => {
   it("returns the original array if sortDirection is not provided", () => {
@@ -48,6 +48,36 @@ describe("sortByNumericValue", () => {
   });
 });
 
+describe.only("sortByUpdatedAt", () => {
+  it("sorts the repos by the date they were last updated in ascending order", () => {
+    const reposToSort = [
+      { name: "Repo 1", updatedAtISO8601: "2022-01-01T00:00:00Z" },
+      { name: "Repo 2", updatedAtISO8601: "2021-01-01T00:00:00Z" },
+      { name: "Repo 3", updatedAtISO8601: "2023-01-01T00:00:00Z" },
+    ];
+
+    expect.deepEqual(sortByUpdatedAt(reposToSort, "asc"), [
+      { name: "Repo 2", updatedAtISO8601: "2021-01-01T00:00:00Z" },
+      { name: "Repo 1", updatedAtISO8601: "2022-01-01T00:00:00Z" },
+      { name: "Repo 3", updatedAtISO8601: "2023-01-01T00:00:00Z" },
+    ]);
+  });
+
+  it("sorts the repos by the date they were last updated in descending order", () => {
+    const reposToSort = [
+      { name: "Repo 1", updatedAtISO8601: "2022-01-01T00:00:00Z" },
+      { name: "Repo 2", updatedAtISO8601: "2021-01-01T00:00:00Z" },
+      { name: "Repo 3", updatedAtISO8601: "2023-01-01T00:00:00Z" },
+    ];
+
+    expect.deepEqual(sortByUpdatedAt(reposToSort, "desc"), [
+      { name: "Repo 3", updatedAtISO8601: "2023-01-01T00:00:00Z" },
+      { name: "Repo 1", updatedAtISO8601: "2022-01-01T00:00:00Z" },
+      { name: "Repo 2", updatedAtISO8601: "2021-01-01T00:00:00Z" },
+    ]);
+  });
+});
+
 describe("sortByType", () => {
   it("sorts the repos by number of open PRs", () => {
     const reposToSort = [
@@ -83,5 +113,18 @@ describe("sortByType", () => {
     ];
 
     expect.deepEqual(sortByType(reposToSort, "asc", null), reposToSort);
+  });
+
+  it('sorts the repos by the date they were last updated if "updatedAt" is provided', () => {
+    const reposToSort = [
+      { name: "Repo 1", updatedAtISO8601: "2022-01-01T00:00:00Z" },
+      { name: "Repo 2", updatedAtISO8601: "2021-01-01T00:00:00Z" },
+      { name: "Repo 3", updatedAtISO8601: "2023-01-01T00:00:00Z" },
+    ];
+
+    expect.deepEqual(
+      sortByType(reposToSort, "asc", "updatedAt"),
+      sortByUpdatedAt(reposToSort, "asc")
+    );
   });
 });

--- a/utils/sorting.test.js
+++ b/utils/sorting.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import expect from "node:assert";
-import { sortByOpenPrs, sortByNumericValue } from "./sorting.js";
+import { sortByOpenPrs, sortByNumericValue, sortByType } from "./sorting.js";
 
 describe("sortByOpenPrs", () => {
   it("returns the original array if sortDirection is not provided", () => {
@@ -91,5 +91,43 @@ describe("sortByNumericValue", () => {
       { name: "Repo 1", value: 5 },
       { name: "Repo 2", value: 3 },
     ]);
+  });
+});
+
+describe("sortByType", () => {
+  it("sorts the repos by number of open PRs", () => {
+    const reposToSort = [
+      { name: "Repo 1", openPrsCount: 5 },
+      { name: "Repo 2", openPrsCount: 3 },
+      { name: "Repo 3", openPrsCount: 7 },
+    ];
+
+    expect.deepEqual(
+      sortByType(reposToSort, "asc", "openPrsCount"),
+      sortByNumericValue(reposToSort, "asc", "openPrsCount")
+    );
+  });
+
+  it("sorts the repos by number of open issues", () => {
+    const reposToSort = [
+      { name: "Repo 1", openIssues: 5 },
+      { name: "Repo 2", openIssues: 3 },
+      { name: "Repo 3", openIssues: 7 },
+    ];
+
+    expect.deepEqual(
+      sortByType(reposToSort, "asc", "openIssues"),
+      sortByNumericValue(reposToSort, "asc", "openIssues")
+    );
+  });
+
+  it("returns the original array if the sortBy parameter is passed", () => {
+    const reposToSort = [
+      { name: "Repo 1", openIssues: 5 },
+      { name: "Repo 2", openIssues: 3 },
+      { name: "Repo 3", openIssues: 7 },
+    ];
+
+    expect.deepEqual(sortByType(reposToSort, "asc", null), reposToSort);
   });
 });

--- a/utils/sorting.test.js
+++ b/utils/sorting.test.js
@@ -1,0 +1,49 @@
+import { describe, it } from "node:test";
+import expect from "node:assert";
+import { sortByOpenPrs } from "./sorting.js";
+
+describe("sortByOpenPrs", () => {
+  it("returns the original array if sortDirection is not provided", () => {
+    const repos = [
+      { name: "Repo 1", openPrsCount: 5 },
+      { name: "Repo 2", openPrsCount: 3 },
+      { name: "Repo 3", openPrsCount: 7 },
+    ];
+
+    const result = sortByOpenPrs(repos);
+
+    expect.deepEqual(result, repos);
+  });
+
+  it("sorts the array in ascending order by openPrsCount if sortDirection is 'asc'", () => {
+    const repos = [
+      { name: "Repo 1", openPrsCount: 5 },
+      { name: "Repo 2", openPrsCount: 3 },
+      { name: "Repo 3", openPrsCount: 7 },
+    ];
+
+    const result = sortByOpenPrs(repos, "asc");
+
+    expect.deepEqual(result, [
+      { name: "Repo 2", openPrsCount: 3 },
+      { name: "Repo 1", openPrsCount: 5 },
+      { name: "Repo 3", openPrsCount: 7 },
+    ]);
+  });
+
+  it("sorts the array in descending order by openPrsCount if sortDirection is 'desc'", () => {
+    const repos = [
+      { name: "Repo 1", openPrsCount: 5 },
+      { name: "Repo 2", openPrsCount: 3 },
+      { name: "Repo 3", openPrsCount: 7 },
+    ];
+
+    const result = sortByOpenPrs(repos, "desc");
+
+    expect.deepEqual(result, [
+      { name: "Repo 3", openPrsCount: 7 },
+      { name: "Repo 1", openPrsCount: 5 },
+      { name: "Repo 2", openPrsCount: 3 },
+    ]);
+  });
+});

--- a/utils/sorting.test.js
+++ b/utils/sorting.test.js
@@ -1,52 +1,6 @@
 import { describe, it } from "node:test";
 import expect from "node:assert";
-import { sortByOpenPrs, sortByNumericValue, sortByType } from "./sorting.js";
-
-describe("sortByOpenPrs", () => {
-  it("returns the original array if sortDirection is not provided", () => {
-    const repos = [
-      { name: "Repo 1", openPrsCount: 5 },
-      { name: "Repo 2", openPrsCount: 3 },
-      { name: "Repo 3", openPrsCount: 7 },
-    ];
-
-    const result = sortByOpenPrs(repos);
-
-    expect.deepEqual(result, repos);
-  });
-
-  it("sorts the array in ascending order by openPrsCount if sortDirection is 'asc'", () => {
-    const repos = [
-      { name: "Repo 1", openPrsCount: 5 },
-      { name: "Repo 2", openPrsCount: 3 },
-      { name: "Repo 3", openPrsCount: 7 },
-    ];
-
-    const result = sortByOpenPrs(repos, "asc");
-
-    expect.deepEqual(result, [
-      { name: "Repo 2", openPrsCount: 3 },
-      { name: "Repo 1", openPrsCount: 5 },
-      { name: "Repo 3", openPrsCount: 7 },
-    ]);
-  });
-
-  it("sorts the array in descending order by openPrsCount if sortDirection is 'desc'", () => {
-    const repos = [
-      { name: "Repo 1", openPrsCount: 5 },
-      { name: "Repo 2", openPrsCount: 3 },
-      { name: "Repo 3", openPrsCount: 7 },
-    ];
-
-    const result = sortByOpenPrs(repos, "desc");
-
-    expect.deepEqual(result, [
-      { name: "Repo 3", openPrsCount: 7 },
-      { name: "Repo 1", openPrsCount: 5 },
-      { name: "Repo 2", openPrsCount: 3 },
-    ]);
-  });
-});
+import { sortByNumericValue, sortByType } from "./sorting.js";
 
 describe("sortByNumericValue", () => {
   it("returns the original array if sortDirection is not provided", () => {


### PR DESCRIPTION
To enable users to see which repos need the most attention we want to be able to sort them. 
This PR introduces sorting by Open PRs, Open Issues and the Updated At colums. 
The user can click the table header to sort.
![image](https://github.com/user-attachments/assets/360d96ba-91d2-48b2-a675-7051ca823c47)

