### PR TITLE
Add 404 path

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,13 @@ nunjucks.configure({
 });
 
 const httpServer = createServer(async (request, response) => {
+  const url = new URL(request.url, `http://${request.headers.host}`);
+
+  if (url.pathname !== "/") {
+    response.writeHead(404);
+    return response.end();
+  }
+
   const pathToRepos = "./data/repos.json";
   const persistedData = await getReposFromJson(pathToRepos);
 


### PR DESCRIPTION
Previously this code was running on every request, even the ones for favicons and service workers. Now we only run on the "/" path.