### PR TITLE
Display upcoming end-of-life dates for dependencies

### DIFF
--- a/index.njk
+++ b/index.njk
@@ -75,21 +75,35 @@
                       <li>
                         <div class="inline-block whitespace-nowrap text-[0px]">
                           <span>
-                          <span class="font-mono text-sm bg-{{ dependency.color }}-200 rounded-l-full last:rounded-r-full py-1 px-2">{{ dependency.name }}</span>
-                          {% if dependency.version %}
-                          <span class="font-mono text-sm bg-{{ dependency.color }}-300 last:rounded-r-full py-1 px-2">v{{ dependency.version }}</span>
-                          {% endif %}
-                          {% if dependency.tag %}
-                          <span class="font-mono text-sm bg-{{ dependency.color }}-400 text-white last:rounded-r-full py-1 px-2">{{ dependency.tag }}</span>
-                          {% endif %}
+                            <span class="font-mono text-sm bg-{{ dependency.color }}-200 rounded-l-full last:rounded-r-full py-1 px-2">{{ dependency.name }}</span>
+                            {% if dependency.version %}
+                            <span class="font-mono text-sm bg-{{ dependency.color }}-300 last:rounded-r-full py-1 px-2">v{{ dependency.version }}</span>
+                            {% endif %}
+                            {% if dependency.tag %}
+                            <span class="font-mono text-sm bg-{{ dependency.color }}-400 text-white last:rounded-r-full py-1 px-2">{{ dependency.tag }}</span>
+                            {% endif %}
                           </span>
-                          {% if dependency.isOutdated %}
                           <span class="inline-block w-1"></span>
-                          <span class="font-mono text-sm bg-{{ dependency.color }}-500 text-white rounded-full py-1 px-2">  
-                            <i class="align-[-1px] bx {{dependency.icon}}"></i>
-                            v{{ dependency.latestVersion }}
+                          <span>
+                            {% if dependency.isOutdated %}
+                            <span class="font-mono text-sm bg-{{ dependency.color }}-500 text-white first:rounded-l-full last:rounded-r-full py-1 px-2">  
+                              <i class="align-[-1px] bx {{dependency.icon}}"></i>
+                              {{ dependency.changelog }}
+                              v{{ dependency.latestVersion }}
+                            </span>
+                            {% endif %}
+                            {% if dependency.isEndOfLifeSoon %}
+                            <span class="font-mono text-sm bg-{{ dependency.color }}-600 text-white first:rounded-l-full last:rounded-r-full py-1 px-2">
+                              <i class="align-[-1px] bx bxs-hourglass"></i>
+                              <span class="font-sans">Support ends {{ dependency.endOfLifeRelative }}</span>
+                            </span>
+                            {% elif dependency.isOutOfSupport %}
+                            <span class="font-mono text-sm bg-{{ dependency.color }}-600 text-white first:rounded-l-full last:rounded-r-full py-1 px-2">
+                              <i class="align-[-1px] bx bxs-hourglass-bottom"></i>
+                              <span class="font-sans">Support ended {{ dependency.endOfLifeRelative }}</span>
+                            </span>
+                            {% endif %}
                           </span>
-                          {% endif%}
                         </div>
                       </li>
                     {% endfor %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@octokit/app": "^15.1.0",
+        "date-fns": "^4.1.0",
         "nunjucks": "^3.2.4",
         "undici": "^6.19.8"
       },
@@ -788,6 +789,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "@octokit/app": "^15.1.0",
+    "date-fns": "^4.1.0",
     "nunjucks": "^3.2.4",
     "undici": "^6.19.8"
   },

--- a/utils/endOfLifeDateApi/index.test.js
+++ b/utils/endOfLifeDateApi/index.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import expect from "node:assert";
-import { getDependencyState } from "./index.js";
+import { getDependencyEndOfLifeDate, getDependencyState } from "./index.js";
 import { Dependency } from "../../model/Dependency.js";
 
 describe("getDependencyState", () => {
@@ -103,4 +103,39 @@ describe("getDependencyState", () => {
       "upToDate",
     );
   })
+});
+
+describe("getDependencyEndOfLifeDate", () => {
+  it("should return undefined by default", () => {
+    const dependency = new Dependency("ruby", "3.3.5");
+    const cycles = [];
+
+    const result = getDependencyEndOfLifeDate(dependency, cycles);
+
+    expect.strictEqual(
+      result,
+      undefined,
+    );
+  });
+
+  it("should return the end-of-life date from the correct cycle", () => {
+    const dependency = new Dependency("ruby", "3.3.5");
+    const cycles = [
+      {
+        cycle: "4",
+        eol: "9999-01-01",
+      },
+      {
+        cycle: "3",
+        eol: "2024-01-01",
+      },
+    ];
+
+    const result = getDependencyEndOfLifeDate(dependency, cycles);
+
+    expect.deepStrictEqual(
+      result,
+      new Date("2024-01-01"),
+    );
+  });
 });


### PR DESCRIPTION
Dependencies are considered to be near the end of their life when there is less than one year of support remaining.

In this case, the second capsule used to display the latest version of the dependency has been expanded to provide a timescale for this deadline in a relative format, with an icon as a secondary visual indicator:
- `bxs-hourglass` (<img height="14px" src="https://raw.githubusercontent.com/atisawd/boxicons/master/svg/solid/bxs-hourglass.svg" />) is used when the end-of-life date is upcoming
- `bxs-hourglass-bottom` (<img height="14px" src="https://raw.githubusercontent.com/atisawd/boxicons/master/svg/solid/bxs-hourglass-bottom.svg" />) is used when the end-of-life date has passed.

Example of an end-of-life dependency and a dependency with an upcoming end-of-life date:
<img width="518" alt="image" src="https://github.com/user-attachments/assets/8aab6211-3e23-4444-af9b-83270e496d2b">

Example of dependencies with updates but with more than a year of support remaining, which are visually unchanged:
<img width="301" alt="image" src="https://github.com/user-attachments/assets/3b34398f-c8fc-4c76-944b-7a4eb4a9abf5">
