### PR TITLE
Fix JSDoc paths

### DIFF
--- a/utils/githubApi/fetchAllRepos.js
+++ b/utils/githubApi/fetchAllRepos.js
@@ -6,6 +6,10 @@ import { getDependenciesForRepo } from "../renovate/dependencyDashboard.js";
 import { getOpenPRsForRepo } from "./fetchOpenPrs.js";
 
 /**
+ * @typedef {import('../index.js').StoredRepo} StoredRepo
+ */
+
+/**
  * Fetches all repos from the GitHub API.
  * Each repo is enriched with data fetched through further API calls
  * @returns {Promise<StoredRepo[]>}

--- a/utils/sorting.js
+++ b/utils/sorting.js
@@ -4,6 +4,9 @@
  * @property {"asc"} ASC
  * @property {"desc"} DESC
  */
+/**
+ * @typedef {import('./index').UiRepo} UiRepo
+ */
 
 /**
  * Sorts repos by the a numeric value


### PR DESCRIPTION
I didn't realise the types had to be imported this way, otherwise they show as `any`.