### PR TITLE
Display ages of newest and oldest issues and pull requests

### DIFF
--- a/index.njk
+++ b/index.njk
@@ -41,6 +41,10 @@
                 {{macros.sortableTableHeader("Open bot PR count", "openBotPrCount", sortDirection, sortBy)}}
                 {{macros.sortableTableHeader("Open PR count", "openPrCount", sortDirection, sortBy)}}
                 {{macros.sortableTableHeader("Updated at", "updatedAt", sortDirection, sortBy)}}
+                {{macros.sortableTableHeader("Most recent PR opened", "mostRecentPrOpenedAt", sortDirection, sortBy)}}
+                {{macros.sortableTableHeader("Oldest open PR opened", "oldestOpenPrOpenedAt", sortDirection, sortBy)}}
+                {{macros.sortableTableHeader("Most recent issue opened", "mostRecentIssueOpenedAt", sortDirection, sortBy)}}
+                {{macros.sortableTableHeader("Oldest open issue opened", "oldestOpenIssueOpenedAt", sortDirection, sortBy)}}
                 <th class="py-2 pl-2 last:pr-2" scope="col">Dependencies</th>
               </tr>
             </thead>
@@ -55,6 +59,10 @@
                 <td class="py-2 pl-2">{{ repo.openBotPrCount }}</td>
                 <td class="py-2 pl-2">{{ repo.openPrCount }}</td>
                 <td class="py-2 pl-2 last:pr-2">{{ repo.updatedAt }}</td>
+                <td class="py-2 pl-2 last:pr-2">{{ repo.mostRecentPrOpenedAt }}</td>
+                <td class="py-2 pl-2 last:pr-2">{{ repo.oldestOpenPrOpenedAt }}</td>
+                <td class="py-2 pl-2 last:pr-2">{{ repo.mostRecentIssueOpenedAt }}</td>
+                <td class="py-2 pl-2 last:pr-2">{{ repo.oldestOpenIssueOpenedAt }}</td>
 
                 {% if repo.dependencies.length %}
                 <td class="group py-2 pl-2 last:pr-2 align-text-top space-y-2">

--- a/utils/githubApi/fetchAllRepos.js
+++ b/utils/githubApi/fetchAllRepos.js
@@ -4,6 +4,7 @@ import { mapRepoFromApiForStorage } from "../index.js";
 import path from "path";
 import { getDependenciesForRepo } from "../renovate/dependencyDashboard.js";
 import { getOpenPRsForRepo } from "./fetchOpenPrs.js";
+import { getOpenIssuesForRepo } from "./fetchOpenIssues.js";
 
 /**
  * @typedef {import('../index.js').StoredRepo} StoredRepo
@@ -23,17 +24,21 @@ const fetchAllRepos = async () => {
     let repo = mapRepoFromApiForStorage(repository);
 
     await Promise.all([
-      await getDependenciesForRepo({
+      getDependenciesForRepo({
         repository,
         octokit,
       }),
-      await getOpenPRsForRepo({
+      getOpenPRsForRepo({
         repository,
         octokit,
       }),
-    ]).then(([dependencies, prInfo]) => {
+      getOpenIssuesForRepo({
+        repository,
+        octokit,
+      }),
+    ]).then(([dependencies, prInfo, issueInfo ]) => {
       repo.dependencies = dependencies;
-      repo = { ...repo, ...prInfo };
+      repo = { ...repo, ...prInfo, ...issueInfo };
     });
 
     repos.push(repo);

--- a/utils/githubApi/fetchOpenIssues.js
+++ b/utils/githubApi/fetchOpenIssues.js
@@ -1,0 +1,47 @@
+/**
+ * Requests the open issues for a given repository
+ * @param {any} {octokit
+ * @param {any} repository}
+ * @returns {Issueomise<number>}
+ */
+export const getOpenIssuesForRepo = async ({ octokit, repository }) => {
+  return octokit.request(repository.issues_url).then(handleIssuesApiResponse);
+};
+
+const issueIsPullRequest = (issue) => issue.pull_request !== undefined;
+const issueIsBotIssue = (issue) => issue.user.login === "renovate[bot]"
+
+/**
+ * Transforms the response from the repo issues endpoint into data relevant to Towtruck.
+ * @param {any} {data} 
+ * @returns
+ */
+export const handleIssuesApiResponse = ({ data }) => {
+  const mostRecentIssueOpenedAt = data.reduce((latestDate, issue) => {
+    if (issueIsPullRequest(issue) || issueIsBotIssue(issue)) {
+      return latestDate;
+    }
+
+    const issueOpenedAt = new Date(issue.created_at);
+    if (latestDate < issueOpenedAt) {
+      return issueOpenedAt;
+    }
+
+    return latestDate;
+  }, null);
+
+  const oldestOpenIssueOpenedAt = data.reduce((oldestDate, issue) => {
+    if (issue.state !== "open" || issueIsPullRequest(issue) || issueIsBotIssue(issue)) {
+      return oldestDate;
+    }
+
+    const issueOpenedAt = new Date(issue.created_at);
+    if (!oldestDate || oldestDate > issueOpenedAt) {
+      return issueOpenedAt;
+    }
+
+    return oldestDate;
+  }, null);
+
+  return { mostRecentIssueOpenedAt, oldestOpenIssueOpenedAt };
+};

--- a/utils/githubApi/fetchOpenIssues.test.js
+++ b/utils/githubApi/fetchOpenIssues.test.js
@@ -1,0 +1,79 @@
+import { describe, it } from "node:test";
+import expect from "node:assert";
+import { handleIssuesApiResponse } from "./fetchOpenIssues.js";
+
+describe("handleIssuesApiResponse", () => {
+  describe("mostRecentIssueOpenedAt", () => {
+    it("returns null if there are no issues", () => {
+      const actual = handleIssuesApiResponse({ data: [] });
+
+      expect.strictEqual(actual.mostRecentIssueOpenedAt, null);
+    });
+
+    it("ignores issues opened by Renovate", () => {
+      const renovateIssue = { created_at: "2024-01-01T12:34:56Z", user: { login: "renovate[bot]" } };
+      const openIssue = { created_at: "2023-01-01T12:34:56Z", user: { login: "dan" } };
+      const actual = handleIssuesApiResponse({ data: [renovateIssue, openIssue] });
+
+      expect.deepEqual(actual.mostRecentIssueOpenedAt, new Date(openIssue.created_at));
+    });
+
+    it("ignores issues that are pull requests", () => {
+      const pullRequest = { created_at: "2024-01-01T12:34:56Z", user: { login: "dan" }, pull_request: {} };
+      const openIssue = { created_at: "2023-01-01T12:34:56Z", user: { login: "dan" } };
+      const actual = handleIssuesApiResponse({ data: [pullRequest, openIssue] });
+
+      expect.deepEqual(actual.mostRecentIssueOpenedAt, new Date(openIssue.created_at));
+    });
+
+    it ("returns the latest value of created_at among all elements in the list", () => {
+      const issue1 = { created_at: "2024-01-01T12:34:56Z", user: { login: "dan" } };
+      const issue2 = { created_at: "2024-02-02T12:34:56Z", user: { login: "dan" } };
+
+      const actual = handleIssuesApiResponse({ data: [issue1, issue2] });
+
+      expect.deepStrictEqual(actual.mostRecentIssueOpenedAt, new Date(issue2.created_at));
+    });
+  });
+
+  describe("oldestOpenIssueOpenedAt", () => {
+    it("returns null if there are no issues", () => {
+      const actual = handleIssuesApiResponse({ data: [] });
+
+      expect.deepEqual(actual.oldestOpenIssueOpenedAt, null);
+    });
+
+    it("returns null if there are no open issues", () => {
+      const closedIssue = { created_at: "2024-01-01T12:34:56Z", state: "closed", user: { login: "dan" } }
+      const actual = handleIssuesApiResponse({ data: [closedIssue] });
+
+      expect.deepEqual(actual.oldestOpenIssueOpenedAt, null);
+    });
+
+    it("ignores issues opened by Renovate", () => {
+      const renovateIssue = { created_at: "2023-01-01T12:34:56Z", state: "open", user: { login: "renovate[bot]" } };
+      const openIssue = { created_at: "2024-01-01T12:34:56Z", state: "open", user: { login: "dan" } };
+      const actual = handleIssuesApiResponse({ data: [renovateIssue, openIssue] });
+
+      expect.deepEqual(actual.oldestOpenIssueOpenedAt, new Date(openIssue.created_at));
+    });
+
+    it("ignores issues that are pull requests", () => {
+      const pullRequest = { created_at: "2023-01-01T12:34:56Z", state: "open", user: { login: "dan" }, pull_request: {} };
+      const openIssue = { created_at: "2024-01-01T12:34:56Z", state: "open", user: { login: "dan" } };
+      const actual = handleIssuesApiResponse({ data: [pullRequest, openIssue] });
+
+      expect.deepEqual(actual.oldestOpenIssueOpenedAt, new Date(openIssue.created_at));
+    });
+
+    it ("returns the earliest value of created_at among all elements in the list with a state of 'open'", () => {
+      const closedIssue = { created_at: "2023-12-31T12:34:56Z", state: "closed", user: { login: "dan" } };
+      const openIssue1 = { created_at: "2024-01-01T12:34:56Z", state: "open", user: { login: "dan" } };
+      const openIssue2 = { created_at: "2024-02-02T12:34:56Z", state: "open", user: { login: "dan" } };
+
+      const actual = handleIssuesApiResponse({ data: [closedIssue, openIssue1, openIssue2] });
+
+      expect.deepStrictEqual(actual.oldestOpenIssueOpenedAt, new Date(openIssue1.created_at));
+    });
+  });
+});

--- a/utils/githubApi/fetchOpenPrs.js
+++ b/utils/githubApi/fetchOpenPrs.js
@@ -23,5 +23,26 @@ export const handlePrsApiResponse = ({ data }) => {
     return acc;
   }, 0);
 
-  return { openPrCount: data?.length || 0, openBotPrCount };
+  const mostRecentPrOpenedAt = data.reduce((latestDate, pr) => {
+    const prOpenedAt = new Date(pr.created_at);
+    if (latestDate < prOpenedAt) {
+      return prOpenedAt;
+    }
+    return latestDate;
+  }, null);
+
+  const oldestOpenPrOpenedAt = data.reduce((oldestDate, pr) => {
+    if (pr.state !== "open") {
+      return oldestDate;
+    }
+
+    const prOpenedAt = new Date(pr.created_at);
+    if (!oldestDate || oldestDate > prOpenedAt) {
+      return prOpenedAt;
+    }
+
+    return oldestDate;
+  }, null);
+
+  return { openPrCount: data?.length || 0, openBotPrCount, mostRecentPrOpenedAt, oldestOpenPrOpenedAt };
 };

--- a/utils/githubApi/fetchOpenPrs.test.js
+++ b/utils/githubApi/fetchOpenPrs.test.js
@@ -6,16 +6,14 @@ describe("handlePrsApiResponse", () => {
   describe("openPrCount", () => {
     it("returns the length of the array containing PRs", () => {
       const actual = handlePrsApiResponse({ data: [1, 2, 3] });
-      const expected = { openPrCount: 3, openBotPrCount: 0 };
 
-      expect.deepEqual(actual, expected);
+      expect.strictEqual(actual.openPrCount, 3);
     });
 
     it("returns 0 if there are no open PRs", () => {
       const actual = handlePrsApiResponse({ data: [] });
-      const expected = { openPrCount: 0, openBotPrCount: 0 };
 
-      expect.deepEqual(actual, expected);
+      expect.strictEqual(actual.openPrCount, 0);
     });
   });
 
@@ -63,5 +61,47 @@ describe("handlePrsApiResponse", () => {
 
       expect.equal(actual.openBotPrCount, 2);
     });
+  });
+
+  describe("mostRecentPrOpenedAt", () => {
+    it("returns null if there are no PRs", () => {
+      const actual = handlePrsApiResponse({ data: [] });
+
+      expect.strictEqual(actual.mostRecentPrOpenedAt, null);
+    });
+  });
+
+  it ("returns the latest value of created_at among all elements in the list", () => {
+    const pr1 = { created_at: "2024-01-01T12:34:56Z" };
+    const pr2 = { created_at: "2024-02-02T12:34:56Z" };
+
+    const actual = handlePrsApiResponse({ data: [pr1, pr2] });
+
+    expect.deepStrictEqual(actual.mostRecentPrOpenedAt, new Date(pr2.created_at));
+  });
+
+  describe("oldestOpenPrOpenedAt", () => {
+    it("returns null if there are no PRs", () => {
+      const actual = handlePrsApiResponse({ data: [] });
+
+      expect.deepEqual(actual.oldestOpenPrOpenedAt, null);
+    });
+  });
+
+  it("returns null if there are no open PRs", () => {
+    const closedPr = { created_at: "2024-01-01T12:34:56Z", state: "closed" }
+    const actual = handlePrsApiResponse({ data: [closedPr] });
+
+    expect.deepEqual(actual.oldestOpenPrOpenedAt, null);
+  });
+
+  it ("returns the earliest value of created_at among all elements in the list with a state of 'open'", () => {
+    const closedPr = { created_at: "2023-12-31T12:34:56Z", state: "closed" };
+    const openPr1 = { created_at: "2024-01-01T12:34:56Z", state: "open" };
+    const openPr2 = { created_at: "2024-02-02T12:34:56Z", state: "open" };
+
+    const actual = handlePrsApiResponse({ data: [closedPr, openPr1, openPr2] });
+
+    expect.deepStrictEqual(actual.oldestOpenPrOpenedAt, new Date(openPr1.created_at));
   });
 });

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,5 +1,5 @@
 import { readFile } from "fs/promises";
-import { differenceInYears, formatDistance, startOfToday } from "date-fns";
+import { differenceInYears, formatDistance, formatDistanceToNow, startOfToday } from "date-fns";
 import { getDependencyEndOfLifeDate, getDependencyState } from "./endOfLifeDateApi/index.js";
 
 /**
@@ -105,11 +105,24 @@ export const mapRepoFromStorageToUi = (persistedData, persistedLifetimes) => {
     const newDate = new Date(repo.updatedAt).toLocaleDateString();
     const dependencies = repo.dependencies.map((dependency) => mapDependencyFromStorageToUi(dependency, persistedLifetimes));
 
+    const mostRecentPrOpenedAt = repo.mostRecentPrOpenedAt && formatDistanceToNow(repo.mostRecentPrOpenedAt, { addSuffix: true });
+    const oldestOpenPrOpenedAt = repo.oldestOpenPrOpenedAt && formatDistanceToNow(repo.oldestOpenPrOpenedAt, { addSuffix: true });
+    const mostRecentIssueOpenedAt = repo.mostRecentIssueOpenedAt && formatDistanceToNow(repo.mostRecentIssueOpenedAt, { addSuffix: true });
+    const oldestOpenIssueOpenedAt = repo.oldestOpenIssueOpenedAt && formatDistanceToNow(repo.oldestOpenIssueOpenedAt, { addSuffix: true });
+
     return {
       ...repo,
       updatedAt: newDate,
       updatedAtISO8601: repo.updatedAt,
       dependencies,
+      mostRecentPrOpenedAt,
+      mostRecentPrOpenedAtISO8601: repo.mostRecentPrOpenedAt,
+      oldestOpenPrOpenedAt,
+      oldestOpenPrOpenedAtISO8601: repo.oldestOpenPrOpenedAt,
+      mostRecentIssueOpenedAt,
+      mostRecentIssueOpenedAtISO8601: repo.mostRecentIssueOpenedAt,
+      oldestOpenIssueOpenedAt,
+      oldestOpenIssueOpenedAtISO8601: repo.oldestOpenIssueOpenedAt,
     };
   });
 

--- a/utils/index.test.js
+++ b/utils/index.test.js
@@ -1,9 +1,10 @@
 import { describe, it } from "node:test";
 import expect from "node:assert";
 import { mapRepoFromStorageToUi, mapRepoFromApiForStorage } from "./index.js";
+import { formatDistanceToNow } from "date-fns";
 
 describe("mapRepoFromStorageToUi", () => {
-  it("converts the ISO8601 date to a human-readable date", () => {
+  it("converts ISO8601 timestamps to human-readable forms", () => {
     const storedRepos = [
       {
         name: "repo1",
@@ -17,6 +18,10 @@ describe("mapRepoFromStorageToUi", () => {
         topics: [],
         openIssues: 0,
         dependencies: [],
+        mostRecentPrOpenedAt: "2021-01-01T00:00:00Z",
+        oldestOpenPrOpenedAt: "2022-02-02T00:00:00Z",
+        mostRecentIssueOpenedAt: "2023-03-03T00:00:00Z",
+        oldestOpenIssueOpenedAt: "2024-04-04T00:00:00Z",
       },
     ];
 
@@ -38,6 +43,14 @@ describe("mapRepoFromStorageToUi", () => {
         topics: [],
         openIssues: 0,
         dependencies: [],
+        mostRecentPrOpenedAt: formatDistanceToNow(new Date("2021-01-01T00:00:00Z"), { addSuffix: true }),
+        mostRecentPrOpenedAtISO8601: "2021-01-01T00:00:00Z",
+        oldestOpenPrOpenedAt: formatDistanceToNow(new Date("2022-02-02T00:00:00Z"), { addSuffix: true }),
+        oldestOpenPrOpenedAtISO8601: "2022-02-02T00:00:00Z",
+        mostRecentIssueOpenedAt: formatDistanceToNow(new Date("2023-03-03T00:00:00Z"), { addSuffix: true }),
+        mostRecentIssueOpenedAtISO8601: "2023-03-03T00:00:00Z",
+        oldestOpenIssueOpenedAt: formatDistanceToNow(new Date("2024-04-04T00:00:00Z"), { addSuffix: true }),
+        oldestOpenIssueOpenedAtISO8601: "2024-04-04T00:00:00Z",
       },
     ];
 

--- a/utils/sorting.js
+++ b/utils/sorting.js
@@ -70,6 +70,19 @@ export const sortByType = (repos, sortDirection, sortBy) => {
 
     case "updatedAt":
       return sortByISO8601Timestamp(repos, sortDirection, "updatedAtISO8601");
+
+    case "mostRecentPrOpenedAt":
+      return sortByISO8601Timestamp(repos, sortDirection, "mostRecentPrOpenedAtISO8601");
+
+    case "oldestOpenPrOpenedAt":
+      return sortByISO8601Timestamp(repos, sortDirection, "oldestOpenPrOpenedAtISO8601");
+
+    case "mostRecentIssueOpenedAt":
+      return sortByISO8601Timestamp(repos, sortDirection, "mostRecentIssueOpenedAtISO8601");
+
+    case "oldestOpenIssueOpenedAt":
+      return sortByISO8601Timestamp(repos, sortDirection, "oldestOpenIssueOpenedAtISO8601");
+
     default:
       return repos;
   }

--- a/utils/sorting.js
+++ b/utils/sorting.js
@@ -24,23 +24,31 @@ export const sortByNumericValue = (repos, sortDirection, key) => {
 };
 
 /**
- * Sorts repositories by the date they were last updated
- * @param {UiRepo[]} repos
- * @param {SortDirection} sortDirection
+ * Compares two strings in lexicographical order.
+ * @param {string?} first 
+ * @param {string?} second 
+ * @returns {number}
+ */
+const lexicographicalSort = (first, second, ascending) => {
+  if (!first) return 1;
+  if (!second) return -1;
+
+  if (ascending) return first.localeCompare(second);
+  return second.localeCompare(first);
+}
+
+/**
+ * Sorts repos by a timestamp value in ISO 8601 (`YYYY-MM-DDThh:mm:ssZ`) format
+ * @param {UiRepo[]} repos 
+ * @param {SortDirection} sortDirection 
+ * @param {string} key 
  * @returns {UiRepo[]}
  */
-export const sortByUpdatedAt = (repos, sortDirection) => {
+export const sortByISO8601Timestamp = (repos, sortDirection, key) => {
   if (!sortDirection) return repos;
 
-  if (sortDirection === "asc") {
-    return repos.sort((a, b) => {
-      return a.updatedAtISO8601.localeCompare(b.updatedAtISO8601);
-    });
-  }
-  return repos.sort((a, b) =>
-    b.updatedAtISO8601.localeCompare(a.updatedAtISO8601)
-  );
-};
+  return repos.sort((a, b) => lexicographicalSort(a[key], b[key], sortDirection === "asc"));
+}
 
 /**
  * Sorts repositories based on the specified type and direction.
@@ -61,7 +69,7 @@ export const sortByType = (repos, sortDirection, sortBy) => {
       return sortByNumericValue(repos, sortDirection, "openIssues");
 
     case "updatedAt":
-      return sortByUpdatedAt(repos, sortDirection);
+      return sortByISO8601Timestamp(repos, sortDirection, "updatedAtISO8601");
     default:
       return repos;
   }

--- a/utils/sorting.test.js
+++ b/utils/sorting.test.js
@@ -139,4 +139,56 @@ describe("sortByType", () => {
       sortByISO8601Timestamp(reposToSort, "asc", "updatedAtISO8601")
     );
   });
+
+  it('sorts the repos by the date they were last updated if "mostRecentPrOpenedAt" is provided', () => {
+    const reposToSort = [
+      { name: "Repo 1", mostRecentPrOpenedAtISO8601: "2022-01-01T00:00:00Z" },
+      { name: "Repo 2", mostRecentPrOpenedAtISO8601: "2021-01-01T00:00:00Z" },
+      { name: "Repo 3", mostRecentPrOpenedAtISO8601: "2023-01-01T00:00:00Z" },
+    ];
+
+    expect.deepEqual(
+      sortByType(reposToSort, "asc", "mostRecentPrOpenedAt"),
+      sortByISO8601Timestamp(reposToSort, "asc", "mostRecentPrOpenedAtISO8601")
+    );
+  });
+
+  it('sorts the repos by the date they were last updated if "oldestOpenPrOpenedAt" is provided', () => {
+    const reposToSort = [
+      { name: "Repo 1", oldestOpenPrOpenedAtISO8601: "2022-01-01T00:00:00Z" },
+      { name: "Repo 2", oldestOpenPrOpenedAtISO8601: "2021-01-01T00:00:00Z" },
+      { name: "Repo 3", oldestOpenPrOpenedAtISO8601: "2023-01-01T00:00:00Z" },
+    ];
+
+    expect.deepEqual(
+      sortByType(reposToSort, "asc", "oldestOpenPrOpenedAt"),
+      sortByISO8601Timestamp(reposToSort, "asc", "oldestOpenPrOpenedAtISO8601")
+    );
+  });
+
+  it('sorts the repos by the date they were last updated if "mostRecentIssueOpenedAt" is provided', () => {
+    const reposToSort = [
+      { name: "Repo 1", mostRecentIssueOpenedAtISO8601: "2022-01-01T00:00:00Z" },
+      { name: "Repo 2", mostRecentIssueOpenedAtISO8601: "2021-01-01T00:00:00Z" },
+      { name: "Repo 3", mostRecentIssueOpenedAtISO8601: "2023-01-01T00:00:00Z" },
+    ];
+
+    expect.deepEqual(
+      sortByType(reposToSort, "asc", "mostRecentIssueOpenedAt"),
+      sortByISO8601Timestamp(reposToSort, "asc", "mostRecentIssueOpenedAtISO8601")
+    );
+  });
+
+  it('sorts the repos by the date they were last updated if "oldestOpenIssueOpenedAt" is provided', () => {
+    const reposToSort = [
+      { name: "Repo 1", oldestOpenIssueOpenedAtISO8601: "2022-01-01T00:00:00Z" },
+      { name: "Repo 2", oldestOpenIssueOpenedAtISO8601: "2021-01-01T00:00:00Z" },
+      { name: "Repo 3", oldestOpenIssueOpenedAtISO8601: "2023-01-01T00:00:00Z" },
+    ];
+
+    expect.deepEqual(
+      sortByType(reposToSort, "asc", "oldestOpenIssueOpenedAt"),
+      sortByISO8601Timestamp(reposToSort, "asc", "oldestOpenIssueOpenedAtISO8601")
+    );
+  });
 });

--- a/utils/sorting.test.js
+++ b/utils/sorting.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import expect from "node:assert";
-import { sortByNumericValue, sortByType, sortByUpdatedAt } from "./sorting.js";
+import { sortByISO8601Timestamp, sortByNumericValue, sortByType } from "./sorting.js";
 
 describe("sortByNumericValue", () => {
   it("returns the original array if sortDirection is not provided", () => {
@@ -48,32 +48,44 @@ describe("sortByNumericValue", () => {
   });
 });
 
-describe("sortByUpdatedAt", () => {
-  it("sorts the repos by the date they were last updated in ascending order", () => {
-    const reposToSort = [
-      { name: "Repo 1", updatedAtISO8601: "2022-01-01T00:00:00Z" },
-      { name: "Repo 2", updatedAtISO8601: "2021-01-01T00:00:00Z" },
-      { name: "Repo 3", updatedAtISO8601: "2023-01-01T00:00:00Z" },
+describe("sortByISO8601Timestamp", () => {
+  it("returns the original array if sortDirection is not provided", () => {
+    const repos = [
+      { name: "Repo 1", value: "2022-01-01T00:00:00Z" },
+      { name: "Repo 2", value: "2021-01-01T00:00:00Z" },
+      { name: "Repo 3", value: "2023-01-01T00:00:00Z" },
     ];
 
-    expect.deepEqual(sortByUpdatedAt(reposToSort, "asc"), [
-      { name: "Repo 2", updatedAtISO8601: "2021-01-01T00:00:00Z" },
-      { name: "Repo 1", updatedAtISO8601: "2022-01-01T00:00:00Z" },
-      { name: "Repo 3", updatedAtISO8601: "2023-01-01T00:00:00Z" },
+    const result = sortByISO8601Timestamp(repos, null, "value");
+
+    expect.deepEqual(result, repos);
+  });
+
+  it("sorts the array in ascending order by the specified key if sortDirection is 'asc'", () => {
+    const reposToSort = [
+      { name: "Repo 1", value: "2022-01-01T00:00:00Z" },
+      { name: "Repo 2", value: "2021-01-01T00:00:00Z" },
+      { name: "Repo 3", value: "2023-01-01T00:00:00Z" },
+    ];
+
+    expect.deepEqual(sortByISO8601Timestamp(reposToSort, "asc", "value"), [
+      { name: "Repo 2", value: "2021-01-01T00:00:00Z" },
+      { name: "Repo 1", value: "2022-01-01T00:00:00Z" },
+      { name: "Repo 3", value: "2023-01-01T00:00:00Z" },
     ]);
   });
 
-  it("sorts the repos by the date they were last updated in descending order", () => {
+  it("sorts the array in descending order by the specified key if sortDirection is 'desc'", () => {
     const reposToSort = [
-      { name: "Repo 1", updatedAtISO8601: "2022-01-01T00:00:00Z" },
-      { name: "Repo 2", updatedAtISO8601: "2021-01-01T00:00:00Z" },
-      { name: "Repo 3", updatedAtISO8601: "2023-01-01T00:00:00Z" },
+      { name: "Repo 1", value: "2022-01-01T00:00:00Z" },
+      { name: "Repo 2", value: "2021-01-01T00:00:00Z" },
+      { name: "Repo 3", value: "2023-01-01T00:00:00Z" },
     ];
 
-    expect.deepEqual(sortByUpdatedAt(reposToSort, "desc"), [
-      { name: "Repo 3", updatedAtISO8601: "2023-01-01T00:00:00Z" },
-      { name: "Repo 1", updatedAtISO8601: "2022-01-01T00:00:00Z" },
-      { name: "Repo 2", updatedAtISO8601: "2021-01-01T00:00:00Z" },
+    expect.deepEqual(sortByISO8601Timestamp(reposToSort, "desc", "value"), [
+      { name: "Repo 3", value: "2023-01-01T00:00:00Z" },
+      { name: "Repo 1", value: "2022-01-01T00:00:00Z" },
+      { name: "Repo 2", value: "2021-01-01T00:00:00Z" },
     ]);
   });
 });
@@ -124,7 +136,7 @@ describe("sortByType", () => {
 
     expect.deepEqual(
       sortByType(reposToSort, "asc", "updatedAt"),
-      sortByUpdatedAt(reposToSort, "asc")
+      sortByISO8601Timestamp(reposToSort, "asc", "updatedAtISO8601")
     );
   });
 });


### PR DESCRIPTION
This introduces four new sortable columns in the repository table that can be used to gain a rough idea of the activity level of a repository:
- **Most recent PR opened**: How long ago the newest PR was created.
- **Oldest open PR opened**: How long ago the oldest PR that has not been merged or closed was created.
- **Most recent issue opened**: How long ago the newest non-PR issue was created (excluding the Renovate dependency dashboard).
- **Oldest open issue opened**: How long ago the oldest non-PR issue that has not been closed was created (excluding the Renovate dependency dashboard).

Example:
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/0e18fd08-072a-4272-a2c5-f695f9539eba">
