### PR TITLE
Show counts for Dependabot security alerts

### DIFF
--- a/index.njk
+++ b/index.njk
@@ -45,6 +45,7 @@
                 {{macros.sortableTableHeader("Oldest open PR opened", "oldestOpenPrOpenedAt", sortDirection, sortBy)}}
                 {{macros.sortableTableHeader("Most recent issue opened", "mostRecentIssueOpenedAt", sortDirection, sortBy)}}
                 {{macros.sortableTableHeader("Oldest open issue opened", "oldestOpenIssueOpenedAt", sortDirection, sortBy)}}
+                <th class="py-2 pl-2" scope="col">Dependabot alerts</th>
                 <th class="py-2 pl-2 last:pr-2" scope="col">Dependencies</th>
               </tr>
             </thead>
@@ -63,6 +64,26 @@
                 <td class="py-2 pl-2 last:pr-2">{{ repo.oldestOpenPrOpenedAt }}</td>
                 <td class="py-2 pl-2 last:pr-2">{{ repo.mostRecentIssueOpenedAt }}</td>
                 <td class="py-2 pl-2 last:pr-2">{{ repo.oldestOpenIssueOpenedAt }}</td>
+                <td class="py-2 pl-2 last:pr-2 text-center">
+                  {% if repo.totalOpenAlerts !== undefined %}
+                  <div class="inline-block whitespace-nowrap text-[0px]">
+                    {% set id = [repo.name, "alerts", "critical"] | join("-") %}
+                    {% set mainText = ["<span", " class='font-bold'" if repo.criticalSeverityAlerts, ">", repo.criticalSeverityAlerts, "</span>"] | join('') | safe %}
+                    <div class="inline-block text-sm text-white bg-red-600 first:rounded-l-full last:rounded-r-full first:pl-3 last:pr-3 py-1 px-2">{{macros.tooltip(id, mainText, "Critical severity alerts")}}</div>
+                    {% set id = [repo.name, "alerts", "high"] | join("-") %}
+                    {% set mainText = ["<span", " class='font-bold'" if repo.highSeverityAlerts, ">", repo.highSeverityAlerts, "</span>"] | join('') | safe %}
+                    <div class="inline-block text-sm text-white bg-red-500 first:rounded-l-full last:rounded-r-full first:pl-3 last:pr-3 py-1 px-2">{{macros.tooltip(id, mainText, "High severity alerts")}}</div>
+                    {% set id = [repo.name, "alerts", "medium"] | join("-") %}
+                    {% set mainText = ["<span", " class='font-bold'" if repo.mediumSeverityAlerts, ">", repo.mediumSeverityAlerts, "</span>"] | join('') | safe %}
+                    <div class="inline-block text-sm text-white bg-orange-500 first:rounded-l-full last:rounded-r-full first:pl-3 last:pr-3 py-1 px-2">{{macros.tooltip(id, mainText, "Medium severity alerts")}}</div>
+                    {% set id = [repo.name, "alerts", "low"] | join("-") %}
+                    {% set mainText = ["<span", " class='font-bold'" if repo.lowSeverityAlerts, ">", repo.lowSeverityAlerts, "</span>"] | join('') | safe %}
+                    <div class="inline-block text-sm text-white bg-amber-500 first:rounded-l-full last:rounded-r-full first:pl-3 last:pr-3 py-1 px-2">{{macros.tooltip(id, mainText, "Low severity alerts")}}</div>
+                  </div>
+                  {% else %}
+                    <span class="text-stone-400 font-light italic">Dependabot alerts have been disabled for this repository.</span>
+                  {% endif %}
+                </td>
 
                 {% if repo.dependencies.length %}
                 <td class="group py-2 pl-2 last:pr-2 align-text-top space-y-2">

--- a/macros.njk
+++ b/macros.njk
@@ -46,3 +46,12 @@
 </a>
 </th>
 {% endmacro %}
+
+{% macro tooltip(id, mainText, tooltipText) %}
+<div aria-describedby="{{ id }}" class="group relative inline-block">
+  <span class="border-dotted border-b">{{ mainText }}</span>
+  <div role="tooltip" id="{{ id }}" class="invisible group-focus:visible group-hover:visible absolute -top-8 left-2/4 -translate-x-2/4 text-center z-10 py-0.5 px-2 bg-stone-800 text-white rounded-full after:content-[' '] after:absolute after:top-full after:left-2/4 after:-ml-[4px] after:border-4 after:border-transparent after:border-t-stone-800">
+    {{ tooltipText }}
+  </div>
+</div>
+{% endmacro %}

--- a/utils/githubApi/fetchAllRepos.js
+++ b/utils/githubApi/fetchAllRepos.js
@@ -5,6 +5,7 @@ import path from "path";
 import { getDependenciesForRepo } from "../renovate/dependencyDashboard.js";
 import { getOpenPRsForRepo } from "./fetchOpenPrs.js";
 import { getOpenIssuesForRepo } from "./fetchOpenIssues.js";
+import { getDependabotAlertsForRepo } from "./fetchDependabotAlerts.js";
 
 /**
  * @typedef {import('../index.js').StoredRepo} StoredRepo
@@ -36,9 +37,13 @@ const fetchAllRepos = async () => {
         repository,
         octokit,
       }),
-    ]).then(([dependencies, prInfo, issueInfo ]) => {
+      getDependabotAlertsForRepo({
+        repository,
+        octokit,
+      }),
+    ]).then(([dependencies, prInfo, issueInfo , alerts]) => {
       repo.dependencies = dependencies;
-      repo = { ...repo, ...prInfo, ...issueInfo };
+      repo = { ...repo, ...prInfo, ...issueInfo, ...alerts };
     });
 
     repos.push(repo);

--- a/utils/githubApi/fetchDependabotAlerts.js
+++ b/utils/githubApi/fetchDependabotAlerts.js
@@ -1,0 +1,68 @@
+/**
+ * Requests Dependabot alerts for a given repository
+ * @param {any} {octokit
+ * @param {any} repository}
+ * @returns {Promise<number>}
+ */
+export const getDependabotAlertsForRepo = async ({ octokit, repository }) => {
+  return octokit
+    .request("/repos/{owner}/{repo}/dependabot/alerts", {
+      owner: repository.owner.login,
+      repo: repository.name,
+    })
+    .then(handleDependabotAlertsApiResponse)
+    .catch((error) => {
+      console.error(error);
+      return {};
+    });
+};
+
+/**
+ * Transforms the response from the Dependabot alerts endpoint into data relevant to Towtruck.
+ * @param {any} {data}
+ * @returns
+ */
+export const handleDependabotAlertsApiResponse = ({ data }) => {
+  const totalOpenAlerts = data.reduce((acc, alert) => {
+    if (alert.state === "open") {
+      return acc + 1;
+    }
+    return acc;
+  }, 0);
+
+  const lowSeverityAlerts = data.reduce((acc, alert) => {
+    if (alert.state === "open" && alert.security_vulnerability.severity === "low") {
+      return acc + 1;
+    }
+    return acc;
+  }, 0);
+
+  const mediumSeverityAlerts = data.reduce((acc, alert) => {
+    if (alert.state === "open" && alert.security_vulnerability.severity === "medium") {
+      return acc + 1;
+    }
+    return acc;
+  }, 0);
+
+  const highSeverityAlerts = data.reduce((acc, alert) => {
+    if (alert.state === "open" && alert.security_vulnerability.severity === "high") {
+      return acc + 1;
+    }
+    return acc;
+  }, 0);
+
+  const criticalSeverityAlerts = data.reduce((acc, alert) => {
+    if (alert.state === "open" && alert.security_vulnerability.severity === "critical") {
+      return acc + 1;
+    }
+    return acc;
+  }, 0);
+
+  return {
+    totalOpenAlerts,
+    lowSeverityAlerts,
+    mediumSeverityAlerts,
+    highSeverityAlerts,
+    criticalSeverityAlerts,
+  };
+};

--- a/utils/githubApi/fetchDependabotAlerts.test.js
+++ b/utils/githubApi/fetchDependabotAlerts.test.js
@@ -1,0 +1,99 @@
+import { describe, it } from "node:test";
+import expect from "node:assert";
+import { handleDependabotAlertsApiResponse } from "./fetchDependabotAlerts.js";
+
+describe("handleDependabotAlertsApiResponse", () => {
+  describe("totalOpenAlerts", () => {
+    it("returns the count of alerts with a state of 'open'", () => {
+      const alert1 = { state: "open", security_vulnerability: { severity: "low" } };
+      const alert2 = { ...alert1 };
+      const alert3 = { ...alert1 };
+      const actual = handleDependabotAlertsApiResponse({ data: [alert1, alert2, alert3] });
+
+      expect.strictEqual(actual.totalOpenAlerts, 3);
+    });
+
+    it("returns 0 if there are no open alerts", () => {
+      const alert = { state: "fixed", security_vulnerability: { severity: "low" } };
+      const actual = handleDependabotAlertsApiResponse({ data: [alert] });
+
+      expect.strictEqual(actual.totalOpenAlerts, 0);
+    });
+  });
+
+  describe("lowSeverityAlerts", () => {
+    it("returns the count of alerts with a state of 'open' and a severity of 'low'", () => {
+      const alert1 = { state: "open", security_vulnerability: { severity: "low" } };
+      const alert2 = { state: "open", security_vulnerability: { severity: "high" } };
+      const alert3 = { state: "fixed", security_vulnerability: { severity: "low" } };
+      const actual = handleDependabotAlertsApiResponse({ data: [alert1, alert2, alert3] });
+
+      expect.strictEqual(actual.lowSeverityAlerts, 1);
+    });
+
+    it("returns 0 if there are no low severity alerts", () => {
+      const alert1 = { state: "fixed", security_vulnerability: { severity: "low" } };
+      const alert2 = { state: "open", security_vulnerability: { severity: "high" } };
+      const actual = handleDependabotAlertsApiResponse({ data: [alert1, alert2] });
+
+      expect.strictEqual(actual.lowSeverityAlerts, 0);
+    });
+  });
+
+  describe("mediumSeverityAlerts", () => {
+    it("returns the count of alerts with a state of 'open' and a severity of 'medium'", () => {
+      const alert1 = { state: "open", security_vulnerability: { severity: "medium" } };
+      const alert2 = { state: "open", security_vulnerability: { severity: "high" } };
+      const alert3 = { state: "fixed", security_vulnerability: { severity: "medium" } };
+      const actual = handleDependabotAlertsApiResponse({ data: [alert1, alert2, alert3] });
+
+      expect.strictEqual(actual.mediumSeverityAlerts, 1);
+    });
+
+    it("returns 0 if there are no medium severity alerts", () => {
+      const alert1 = { state: "fixed", security_vulnerability: { severity: "medium" } };
+      const alert2 = { state: "open", security_vulnerability: { severity: "high" } };
+      const actual = handleDependabotAlertsApiResponse({ data: [alert1, alert2] });
+
+      expect.strictEqual(actual.mediumSeverityAlerts, 0);
+    });
+  });
+
+  describe("highSeverityAlerts", () => {
+    it("returns the count of alerts with a state of 'open' and a severity of 'high'", () => {
+      const alert1 = { state: "open", security_vulnerability: { severity: "high" } };
+      const alert2 = { state: "open", security_vulnerability: { severity: "low" } };
+      const alert3 = { state: "fixed", security_vulnerability: { severity: "high" } };
+      const actual = handleDependabotAlertsApiResponse({ data: [alert1, alert2, alert3] });
+
+      expect.strictEqual(actual.highSeverityAlerts, 1);
+    });
+
+    it("returns 0 if there are no high severity alerts", () => {
+      const alert1 = { state: "fixed", security_vulnerability: { severity: "high" } };
+      const alert2 = { state: "open", security_vulnerability: { severity: "low" } };
+      const actual = handleDependabotAlertsApiResponse({ data: [alert1, alert2] });
+
+      expect.strictEqual(actual.highSeverityAlerts, 0);
+    });
+  });
+
+  describe("criticalSeverityAlerts", () => {
+    it("returns the count of alerts with a state of 'open' and a severity of 'critical'", () => {
+      const alert1 = { state: "open", security_vulnerability: { severity: "critical" } };
+      const alert2 = { state: "open", security_vulnerability: { severity: "high" } };
+      const alert3 = { state: "fixed", security_vulnerability: { severity: "critical" } };
+      const actual = handleDependabotAlertsApiResponse({ data: [alert1, alert2, alert3] });
+
+      expect.strictEqual(actual.criticalSeverityAlerts, 1);
+    });
+
+    it("returns 0 if there are no critical severity alerts", () => {
+      const alert1 = { state: "fixed", security_vulnerability: { severity: "critical" } };
+      const alert2 = { state: "open", security_vulnerability: { severity: "high" } };
+      const actual = handleDependabotAlertsApiResponse({ data: [alert1, alert2] });
+
+      expect.strictEqual(actual.criticalSeverityAlerts, 0);
+    });
+  });
+});


### PR DESCRIPTION
This displays information from Dependabot as a four-part capsule:
- Far left, dark red (`red-600`): critical severity alerts
- Left, red (`red-500`): high severity alerts
- Right, orange (`orange-500`): medium severity alerts
- Far right, yellow (`amber-500`): low severity alerts

A tooltip is provided for each number to indicate what the number represents.

Example showing an active tooltip:
<img width="1712" alt="image" src="https://github.com/user-attachments/assets/de0e512e-6251-46c0-90d0-ef0fb7b7410d">
