### PR TITLE
Improve display of information in dashboard

### DIFF
--- a/index.njk
+++ b/index.njk
@@ -19,8 +19,8 @@
     </header>
 
     <div class="container mx-auto flex flex-col mt-6 space-y-6">
-      <div class="bg-stone-50 overflow-hidden rounded-lg border-b-4 border-stone-200 space-y-4">
-        <h2 class="bg-white border-b-2 border-stone-100 text-xl font-bold p-4">{{ name }}</h2>
+      <div class="bg-stone-50 rounded-lg border-b-4 border-stone-200 space-y-4">
+        <h2 class="bg-white rounded-t-lg border-b-2 border-stone-100 text-xl font-bold p-4">{{ name }}</h2>
         <p class="mx-4">
           {% if totalRepos === 1 %}
           There is <span class="font-bold">1</span> repository
@@ -30,13 +30,10 @@
           that Towtruck is tracking for <span class="font-bold">{{ org }}</span>.
         </p>
         <div class="mx-4">
-          <table class="table-auto w-full mb-4 border-y border-stone-200">
-            <thead class="bg-white border-b border-stone-200 text-left">
+          <table class="table-fixed w-full mb-4 border-y border-stone-200">
+            <thead class="sticky top-0 z-20 bg-white border-b border-stone-200 text-left">
               <tr class="space-x-2">
-                <th class="py-2 pl-2" scope="col">Name</th>
-                <th class="py-2 pl-2" scope="col">Description</th>
-                <th class="py-2 pl-2" scope="col">Language</th>
-                <th class="py-2 pl-2" scope="col">Topics</th>
+                <th class="py-2 pl-2 w-5/12" scope="col">Repository</th>
                 {{macros.sortableTableHeader("Open issues count", "openIssues", sortDirection, sortBy)}}
                 {{macros.sortableTableHeader("Open bot PR count", "openBotPrCount", sortDirection, sortBy)}}
                 {{macros.sortableTableHeader("Open PR count", "openPrCount", sortDirection, sortBy)}}
@@ -45,106 +42,120 @@
                 {{macros.sortableTableHeader("Oldest open PR opened", "oldestOpenPrOpenedAt", sortDirection, sortBy)}}
                 {{macros.sortableTableHeader("Most recent issue opened", "mostRecentIssueOpenedAt", sortDirection, sortBy)}}
                 {{macros.sortableTableHeader("Oldest open issue opened", "oldestOpenIssueOpenedAt", sortDirection, sortBy)}}
-                <th class="py-2 pl-2" scope="col">Dependabot alerts</th>
-                <th class="py-2 pl-2 last:pr-2" scope="col">Dependencies</th>
               </tr>
             </thead>
             <tbody>
               {% for repo in repos %}
               <tr class="even:bg-white">
-                <td class="py-2 pl-2" scope="row"><a target="_blank" class="text-blue-600 dark:text-blue-500 hover:underline" href="{{repo.htmlUrl}}">{{ repo.name }}</a></td>
-                <td class="py-2 pl-2">{{ repo.description }}</td>
-                <td class="py-2 pl-2">{{ repo.language }}</td>
-                <td class="py-2 pl-2">{{ repo.topics | join(", ")}}</td>
-                <td class="py-2 pl-2">{{ repo.openIssues }}</td>
-                <td class="py-2 pl-2">{{ repo.openBotPrCount }}</td>
-                <td class="py-2 pl-2">{{ repo.openPrCount }}</td>
-                <td class="py-2 pl-2 last:pr-2">{{ repo.updatedAt }}</td>
+                <td class="py-2 pl-2 align-text-top" scope="row">
+                  <div class="text-[0px]">
+                    <a target="_blank" class="inline-block text-base text-sky-600 dark:text-sky-500 hover:underline" href="{{repo.htmlUrl}}">{{ repo.name }}</a>
+                    {% if repo.language %}
+                    <span class="inline-block text-xs text-{{ repo.languageColor }}-600 border-{{ repo.languageColor }}-600 border rounded-lg ml-2 py-1 px-2">{{ repo.language }}</span>
+                    {% endif %}
+                    {% if repo.totalOpenAlerts !== undefined %}
+                    <div class="inline-block whitespace-nowrap text-[0px] ml-2 align-[-1px]">
+                      {% set id = [repo.name, "alerts", "critical"] | join("-") %}
+                      {% set mainText = ["<span", " class='font-bold'" if repo.criticalSeverityAlerts, ">", repo.criticalSeverityAlerts, "</span>"] | join('') | safe %}
+                      <div class="inline-block text-sm text-white bg-red-600 first:rounded-l-full last:rounded-r-full first:pl-3 last:pr-3 py-1 px-2">{{macros.tooltip(id, mainText, "Critical severity alerts")}}</div>
+                      {% set id = [repo.name, "alerts", "high"] | join("-") %}
+                      {% set mainText = ["<span", " class='font-bold'" if repo.highSeverityAlerts, ">", repo.highSeverityAlerts, "</span>"] | join('') | safe %}
+                      <div class="inline-block text-sm text-white bg-red-500 first:rounded-l-full last:rounded-r-full first:pl-3 last:pr-3 py-1 px-2">{{macros.tooltip(id, mainText, "High severity alerts")}}</div>
+                      {% set id = [repo.name, "alerts", "medium"] | join("-") %}
+                      {% set mainText = ["<span", " class='font-bold'" if repo.mediumSeverityAlerts, ">", repo.mediumSeverityAlerts, "</span>"] | join('') | safe %}
+                      <div class="inline-block text-sm text-white bg-orange-500 first:rounded-l-full last:rounded-r-full first:pl-3 last:pr-3 py-1 px-2">{{macros.tooltip(id, mainText, "Medium severity alerts")}}</div>
+                      {% set id = [repo.name, "alerts", "low"] | join("-") %}
+                      {% set mainText = ["<span", " class='font-bold'" if repo.lowSeverityAlerts, ">", repo.lowSeverityAlerts, "</span>"] | join('') | safe %}
+                      <div class="inline-block text-sm text-white bg-amber-500 first:rounded-l-full last:rounded-r-full first:pl-3 last:pr-3 py-1 px-2">{{macros.tooltip(id, mainText, "Low severity alerts")}}</div>
+                    </div>
+                    {% else %}
+                      <span class="text-stone-400 font-light italic">Dependabot alerts have been disabled for this repository.</span>
+                    {% endif %}
+                  </div>
+                  <p class="mt-2">{{ repo.description }}</p>
+
+                  {% if repo.topics.length %}
+                  <div class="mt-4">
+                    {% for topic in repo.topics %}
+                    <span class="text-xs text-stone-600 bg-stone-200 rounded-full py-1 px-2">{{ topic }}</span>
+                    {% endfor %}
+                  </div>
+                  {% endif %}
+
+                  <hr class="mt-4 w-96 border-stone-200" />
+
+                  <div class="mt-4 mb-2">
+                    {% if repo.dependencies.length %}
+                    <div class="group space-y-2">
+                      <p>
+                        {% if repo.dependencies.length === 1 %}
+                        There is <span class="font-bold">1</span> dependency:
+                        {% else %}
+                        There are <span class="font-bold">{{ repo.dependencies.length }}</span> dependencies:
+                        {% endif %}
+                        <label>
+                          <input class="hidden" type="checkbox" />
+                          <span class="text-sm bg-stone-500 text-white rounded-lg py-1 px-2 hidden group-has-[:checked]:inline">Hide</span>
+                          <span class="text-sm bg-stone-500 text-white rounded-lg py-1 px-2 group-has-[:checked]:hidden">Show</span>
+                        </label>
+                      </p>
+                      <ul class="space-y-2 hidden group-has-[:checked]:block">
+                        {% for dependency in repo.dependencies %}
+                          <li>
+                            <div class="inline-block whitespace-nowrap text-[0px]">
+                              <span>
+                                <span class="font-mono text-sm bg-{{ dependency.color }}-200 rounded-l-full last:rounded-r-full py-1 px-2">{{ dependency.name }}</span>
+                                {% if dependency.version %}
+                                <span class="font-mono text-sm bg-{{ dependency.color }}-300 last:rounded-r-full py-1 px-2">v{{ dependency.version }}</span>
+                                {% endif %}
+                                {% if dependency.tag %}
+                                <span class="font-mono text-sm bg-{{ dependency.color }}-400 text-white last:rounded-r-full py-1 px-2">{{ dependency.tag }}</span>
+                                {% endif %}
+                              </span>
+                              <span class="inline-block w-1"></span>
+                              <span>
+                                {% if dependency.isOutdated %}
+                                <span class="font-mono text-sm bg-{{ dependency.color }}-500 text-white first:rounded-l-full last:rounded-r-full py-1 px-2">  
+                                  <i class="align-[-1px] bx {{dependency.icon}}"></i>
+                                  {{ dependency.changelog }}
+                                  v{{ dependency.latestVersion }}
+                                </span>
+                                {% endif %}
+                                {% if dependency.isEndOfLifeSoon %}
+                                <span class="font-mono text-sm bg-{{ dependency.color }}-600 text-white first:rounded-l-full last:rounded-r-full py-1 px-2">
+                                  <i class="align-[-1px] bx bxs-hourglass"></i>
+                                  <span class="font-sans">Support ends {{ dependency.endOfLifeRelative }}</span>
+                                </span>
+                                {% elif dependency.isOutOfSupport %}
+                                <span class="font-mono text-sm bg-{{ dependency.color }}-600 text-white first:rounded-l-full last:rounded-r-full py-1 px-2">
+                                  <i class="align-[-1px] bx bxs-hourglass-bottom"></i>
+                                  <span class="font-sans">Support ended {{ dependency.endOfLifeRelative }}</span>
+                                </span>
+                                {% endif %}
+                              </span>
+                            </div>
+                          </li>
+                        {% endfor %}
+                      </ul>
+                    </div>
+                    {% else %}
+                      <span class="text-stone-400 font-light italic">
+                        No dependencies have been discovered.
+                        <br/>
+                        Please make sure that Renovate has been configured on the repository to produce a dependency dashboard.
+                      </span>
+                    {% endif %}
+                  </div>
+                </td>
+
+                <td class="py-2 pl-2 align-text-top">{{ repo.openIssues }}</td>
+                <td class="py-2 pl-2 align-text-top">{{ repo.openBotPrCount }}</td>
+                <td class="py-2 pl-2 align-text-top">{{ repo.openPrCount }}</td>
+                <td class="py-2 pl-2 align-text-top">{{ repo.updatedAt }}</td>
                 <td class="py-2 pl-2 last:pr-2">{{ repo.mostRecentPrOpenedAt }}</td>
                 <td class="py-2 pl-2 last:pr-2">{{ repo.oldestOpenPrOpenedAt }}</td>
                 <td class="py-2 pl-2 last:pr-2">{{ repo.mostRecentIssueOpenedAt }}</td>
                 <td class="py-2 pl-2 last:pr-2">{{ repo.oldestOpenIssueOpenedAt }}</td>
-                <td class="py-2 pl-2 last:pr-2 text-center">
-                  {% if repo.totalOpenAlerts !== undefined %}
-                  <div class="inline-block whitespace-nowrap text-[0px]">
-                    {% set id = [repo.name, "alerts", "critical"] | join("-") %}
-                    {% set mainText = ["<span", " class='font-bold'" if repo.criticalSeverityAlerts, ">", repo.criticalSeverityAlerts, "</span>"] | join('') | safe %}
-                    <div class="inline-block text-sm text-white bg-red-600 first:rounded-l-full last:rounded-r-full first:pl-3 last:pr-3 py-1 px-2">{{macros.tooltip(id, mainText, "Critical severity alerts")}}</div>
-                    {% set id = [repo.name, "alerts", "high"] | join("-") %}
-                    {% set mainText = ["<span", " class='font-bold'" if repo.highSeverityAlerts, ">", repo.highSeverityAlerts, "</span>"] | join('') | safe %}
-                    <div class="inline-block text-sm text-white bg-red-500 first:rounded-l-full last:rounded-r-full first:pl-3 last:pr-3 py-1 px-2">{{macros.tooltip(id, mainText, "High severity alerts")}}</div>
-                    {% set id = [repo.name, "alerts", "medium"] | join("-") %}
-                    {% set mainText = ["<span", " class='font-bold'" if repo.mediumSeverityAlerts, ">", repo.mediumSeverityAlerts, "</span>"] | join('') | safe %}
-                    <div class="inline-block text-sm text-white bg-orange-500 first:rounded-l-full last:rounded-r-full first:pl-3 last:pr-3 py-1 px-2">{{macros.tooltip(id, mainText, "Medium severity alerts")}}</div>
-                    {% set id = [repo.name, "alerts", "low"] | join("-") %}
-                    {% set mainText = ["<span", " class='font-bold'" if repo.lowSeverityAlerts, ">", repo.lowSeverityAlerts, "</span>"] | join('') | safe %}
-                    <div class="inline-block text-sm text-white bg-amber-500 first:rounded-l-full last:rounded-r-full first:pl-3 last:pr-3 py-1 px-2">{{macros.tooltip(id, mainText, "Low severity alerts")}}</div>
-                  </div>
-                  {% else %}
-                    <span class="text-stone-400 font-light italic">Dependabot alerts have been disabled for this repository.</span>
-                  {% endif %}
-                </td>
-
-                {% if repo.dependencies.length %}
-                <td class="group py-2 pl-2 last:pr-2 align-text-top space-y-2">
-                  <p>
-                    {% if repo.dependencies.length === 1 %}
-                    There is <span class="font-bold">1</span> dependency:
-                    {% else %}
-                    There are <span class="font-bold">{{ repo.dependencies.length }}</span> dependencies:
-                    {% endif %}
-                    <label>
-                      <input class="hidden" type="checkbox" />
-                      <span class="text-sm bg-stone-500 text-white rounded-lg py-1 px-2 hidden group-has-[:checked]:inline">Hide</span>
-                      <span class="text-sm bg-stone-500 text-white rounded-lg py-1 px-2 group-has-[:checked]:hidden">Show</span>
-                    </label>
-                  </p>
-                  <ul class="space-y-2 hidden group-has-[:checked]:block">
-                    {% for dependency in repo.dependencies %}
-                      <li>
-                        <div class="inline-block whitespace-nowrap text-[0px]">
-                          <span>
-                            <span class="font-mono text-sm bg-{{ dependency.color }}-200 rounded-l-full last:rounded-r-full py-1 px-2">{{ dependency.name }}</span>
-                            {% if dependency.version %}
-                            <span class="font-mono text-sm bg-{{ dependency.color }}-300 last:rounded-r-full py-1 px-2">v{{ dependency.version }}</span>
-                            {% endif %}
-                            {% if dependency.tag %}
-                            <span class="font-mono text-sm bg-{{ dependency.color }}-400 text-white last:rounded-r-full py-1 px-2">{{ dependency.tag }}</span>
-                            {% endif %}
-                          </span>
-                          <span class="inline-block w-1"></span>
-                          <span>
-                            {% if dependency.isOutdated %}
-                            <span class="font-mono text-sm bg-{{ dependency.color }}-500 text-white first:rounded-l-full last:rounded-r-full py-1 px-2">  
-                              <i class="align-[-1px] bx {{dependency.icon}}"></i>
-                              {{ dependency.changelog }}
-                              v{{ dependency.latestVersion }}
-                            </span>
-                            {% endif %}
-                            {% if dependency.isEndOfLifeSoon %}
-                            <span class="font-mono text-sm bg-{{ dependency.color }}-600 text-white first:rounded-l-full last:rounded-r-full py-1 px-2">
-                              <i class="align-[-1px] bx bxs-hourglass"></i>
-                              <span class="font-sans">Support ends {{ dependency.endOfLifeRelative }}</span>
-                            </span>
-                            {% elif dependency.isOutOfSupport %}
-                            <span class="font-mono text-sm bg-{{ dependency.color }}-600 text-white first:rounded-l-full last:rounded-r-full py-1 px-2">
-                              <i class="align-[-1px] bx bxs-hourglass-bottom"></i>
-                              <span class="font-sans">Support ended {{ dependency.endOfLifeRelative }}</span>
-                            </span>
-                            {% endif %}
-                          </span>
-                        </div>
-                      </li>
-                    {% endfor %}
-                  </ul>
-                </td>
-                {% else %}
-                  <td class="py-2 px-2 text-center text-stone-400 font-light italic">
-                    No dependencies have been discovered.
-                    <br/>
-                    Please make sure that Renovate has been configured on the repository to produce a dependency dashboard.
-                  </td>
-                {% endif %}
              
               </tr>
               {% else %}

--- a/index.njk
+++ b/index.njk
@@ -20,7 +20,7 @@
 
     <div class="container mx-auto flex flex-col mt-6 space-y-6">
       <div class="bg-stone-50 rounded-lg border-b-4 border-stone-200 space-y-4">
-        <h2 class="bg-white rounded-t-lg border-b-2 border-stone-100 text-xl font-bold p-4">{{ name }}</h2>
+        <h2 class="bg-white rounded-t-lg border-b-2 border-stone-100 text-xl font-bold p-4">{{ org }}</h2>
         <p class="mx-4">
           {% if totalRepos === 1 %}
           There is <span class="font-bold">1</span> repository

--- a/index.njk
+++ b/index.njk
@@ -148,14 +148,62 @@
                   </div>
                 </td>
 
-                <td class="py-2 pl-2 align-text-top">{{ repo.openIssues }}</td>
-                <td class="py-2 pl-2 align-text-top">{{ repo.openBotPrCount }}</td>
-                <td class="py-2 pl-2 align-text-top">{{ repo.openPrCount }}</td>
-                <td class="py-2 pl-2 align-text-top">{{ repo.updatedAt }}</td>
-                <td class="py-2 pl-2 last:pr-2">{{ repo.mostRecentPrOpenedAt }}</td>
-                <td class="py-2 pl-2 last:pr-2">{{ repo.oldestOpenPrOpenedAt }}</td>
-                <td class="py-2 pl-2 last:pr-2">{{ repo.mostRecentIssueOpenedAt }}</td>
-                <td class="py-2 pl-2 last:pr-2">{{ repo.oldestOpenIssueOpenedAt }}</td>
+                <td class="py-2 pl-2 align-text-top last:pr-2">
+                  <span class="relative">
+                    <span class="sticky top-28">
+                      {{ repo.openIssues }}
+                    </span>
+                  </span>
+                </td>
+                <td class="py-2 pl-2 align-text-top last:pr-2">
+                  <span class="relative">
+                    <span class="sticky top-28">
+                      {{ repo.openBotPrCount }}
+                    </span>
+                  </span>
+                </td>
+                <td class="py-2 pl-2 align-text-top last:pr-2">
+                  <span class="relative">
+                    <span class="sticky top-28">
+                      {{ repo.openPrCount }}
+                    </span>
+                  </span>
+                </td>
+                <td class="py-2 pl-2 align-text-top last:pr-2">
+                  <span class="relative">
+                    <span class="sticky top-28">
+                      {{ repo.updatedAt }}
+                    </span>
+                  </span>
+                </td>
+                <td class="py-2 pl-2 align-text-top last:pr-2">
+                  <span class="relative">
+                    <span class="sticky top-28">
+                      {{ repo.mostRecentPrOpenedAt }}
+                    </span>
+                  </span>
+                </td>
+                <td class="py-2 pl-2 align-text-top last:pr-2">
+                  <span class="relative">
+                    <span class="sticky top-28">
+                      {{ repo.oldestOpenPrOpenedAt }}
+                    </span>
+                  </span>
+                </td>
+                <td class="py-2 pl-2 align-text-top last:pr-2">
+                  <span class="relative">
+                    <span class="sticky top-28">
+                      {{ repo.mostRecentIssueOpenedAt }}
+                    </span>
+                  </span>
+                </td>
+                <td class="py-2 pl-2 align-text-top last:pr-2">
+                  <span class="relative">
+                    <span class="sticky top-28">
+                      {{ repo.oldestOpenIssueOpenedAt }}
+                    </span>
+                  </span>
+                </td>
              
               </tr>
               {% else %}

--- a/macros.njk
+++ b/macros.njk
@@ -31,11 +31,15 @@
 
 <th class="py-2 pl-2" scope="col" aria-sort="{{ariaSort}}"><a href="/{{linkParams}}"> {{name}}
 
-    <span class="text-xs ml-1">
+    <span class="text-xs ml-1 whitespace-nowrap">
         {% if sortDirection === "asc" and sortingOnThisParam %}
+        <div class="w-full">
             {{upArrow | safe}}
+        </div>
         {% elseif sortDirection === 'desc' and sortingOnThisParam %}
+        <div class="w-full">
             {{downArrow | safe}}
+        </div>
         {% elseif id !== sortBy %}
         <div class="w-full">
             {{upArrow | safe}}

--- a/macros.njk
+++ b/macros.njk
@@ -54,7 +54,7 @@
 {% macro tooltip(id, mainText, tooltipText) %}
 <div aria-describedby="{{ id }}" class="group relative inline-block">
   <span class="border-dotted border-b">{{ mainText }}</span>
-  <div role="tooltip" id="{{ id }}" class="invisible group-focus:visible group-hover:visible absolute -top-8 left-2/4 -translate-x-2/4 text-center z-10 py-0.5 px-2 bg-stone-800 text-white rounded-full after:content-[' '] after:absolute after:top-full after:left-2/4 after:-ml-[4px] after:border-4 after:border-transparent after:border-t-stone-800">
+  <div role="tooltip" id="{{ id }}" class="invisible group-focus:visible group-hover:visible absolute -top-8 left-2/4 -translate-x-2/4 text-center z-30 py-0.5 px-2 bg-stone-800 text-white rounded-full after:content-[' '] after:absolute after:top-full after:left-2/4 after:-ml-[4px] after:border-4 after:border-transparent after:border-t-stone-800">
     {{ tooltipText }}
   </div>
 </div>

--- a/utils/index.js
+++ b/utils/index.js
@@ -95,6 +95,44 @@ export const mapDependencyFromStorageToUi = (dependency, persistedLifetimes) => 
 };
 
 /**
+ * Picks a Tailwind colour by hashing the given string.
+ * @param {string} str
+ * @returns {string}
+ */
+export const hashToTailwindColor = (str) => {
+  const languageColors = [
+    "red",
+    "orange",
+    "amber",
+    "yellow",
+    "lime",
+    "green",
+    "emerald",
+    "teal",
+    "cyan",
+    "sky",
+    "blue",
+    "indigo",
+    "violet",
+    "purple",
+    "fuchsia",
+    "pink",
+    "rose",
+  ];
+
+  let languageColor = undefined;
+  if (str && typeof str === "string") {
+    let hash = 0;
+    for (const c of str) {
+      hash = hash * 13 + c.charCodeAt(0) * 19;
+    }
+    languageColor = languageColors[hash % 17];
+  }
+
+  return languageColor;
+};
+
+/**
  * Maps the persisted repo data from storage to a format suitable for the UI
  * @param {PersistedData} persistedData
  * @param {import("./endOfLifeDateApi/fetchAllDependencyEolInfo").DependencyLifetimes[]} persistedLifetimes
@@ -110,6 +148,8 @@ export const mapRepoFromStorageToUi = (persistedData, persistedLifetimes) => {
     const mostRecentIssueOpenedAt = repo.mostRecentIssueOpenedAt && formatDistanceToNow(repo.mostRecentIssueOpenedAt, { addSuffix: true });
     const oldestOpenIssueOpenedAt = repo.oldestOpenIssueOpenedAt && formatDistanceToNow(repo.oldestOpenIssueOpenedAt, { addSuffix: true });
 
+    const languageColor = hashToTailwindColor(repo.language);
+
     return {
       ...repo,
       updatedAt: newDate,
@@ -123,6 +163,7 @@ export const mapRepoFromStorageToUi = (persistedData, persistedLifetimes) => {
       mostRecentIssueOpenedAtISO8601: repo.mostRecentIssueOpenedAt,
       oldestOpenIssueOpenedAt,
       oldestOpenIssueOpenedAtISO8601: repo.oldestOpenIssueOpenedAt,
+      languageColor,
     };
   });
 

--- a/utils/index.test.js
+++ b/utils/index.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import expect from "node:assert";
-import { mapRepoFromStorageToUi, mapRepoFromApiForStorage } from "./index.js";
+import { mapRepoFromStorageToUi, mapRepoFromApiForStorage, hashToTailwindColor } from "./index.js";
 import { formatDistanceToNow } from "date-fns";
 
 describe("mapRepoFromStorageToUi", () => {
@@ -51,6 +51,101 @@ describe("mapRepoFromStorageToUi", () => {
         mostRecentIssueOpenedAtISO8601: "2023-03-03T00:00:00Z",
         oldestOpenIssueOpenedAt: formatDistanceToNow(new Date("2024-04-04T00:00:00Z"), { addSuffix: true }),
         oldestOpenIssueOpenedAtISO8601: "2024-04-04T00:00:00Z",
+        languageColor: undefined,
+      },
+    ];
+
+    expect.deepEqual(mapRepoFromStorageToUi(persistedData).repos, expected);
+  });
+
+  it("converts the language string to a Tailwind colour", () => {
+    const storedRepos = [
+      {
+        name: "repo1",
+        description: "description1",
+        updatedAt: "2021-01-01T00:00:00Z",
+        htmlUrl: "http://url.com/repo1",
+        apiUrl: "http://api.com/repo1",
+        pullsUrl: "http://api.com/repo1/pulls",
+        issuesUrl: "http://api.com/repo1/issues",
+        language: "Ruby",
+        topics: [],
+        openIssues: 0,
+        dependencies: [],
+        mostRecentPrOpenedAt: "2021-01-01T00:00:00Z",
+        oldestOpenPrOpenedAt: "2022-02-02T00:00:00Z",
+        mostRecentIssueOpenedAt: "2023-03-03T00:00:00Z",
+        oldestOpenIssueOpenedAt: "2024-04-04T00:00:00Z",
+      },
+      {
+        name: "repo2",
+        description: "description2",
+        updatedAt: "2021-01-01T00:00:00Z",
+        htmlUrl: "http://url.com/repo2",
+        apiUrl: "http://api.com/repo2",
+        pullsUrl: "http://api.com/repo2/pulls",
+        issuesUrl: "http://api.com/repo2/issues",
+        language: "TypeScript",
+        topics: [],
+        openIssues: 0,
+        dependencies: [],
+        mostRecentPrOpenedAt: "2021-01-01T00:00:00Z",
+        oldestOpenPrOpenedAt: "2022-02-02T00:00:00Z",
+        mostRecentIssueOpenedAt: "2023-03-03T00:00:00Z",
+        oldestOpenIssueOpenedAt: "2024-04-04T00:00:00Z",
+      },
+    ];
+
+    const persistedData = {
+      repos: storedRepos,
+    };
+
+    const expected = [
+      {
+        name: "repo1",
+        description: "description1",
+        updatedAt: new Date("2021-01-01T00:00:00Z").toLocaleDateString(),
+        updatedAtISO8601: "2021-01-01T00:00:00Z",
+        htmlUrl: "http://url.com/repo1",
+        apiUrl: "http://api.com/repo1",
+        pullsUrl: "http://api.com/repo1/pulls",
+        issuesUrl: "http://api.com/repo1/issues",
+        language: "Ruby",
+        topics: [],
+        openIssues: 0,
+        dependencies: [],
+        mostRecentPrOpenedAt: formatDistanceToNow(new Date("2021-01-01T00:00:00Z"), { addSuffix: true }),
+        mostRecentPrOpenedAtISO8601: "2021-01-01T00:00:00Z",
+        oldestOpenPrOpenedAt: formatDistanceToNow(new Date("2022-02-02T00:00:00Z"), { addSuffix: true }),
+        oldestOpenPrOpenedAtISO8601: "2022-02-02T00:00:00Z",
+        mostRecentIssueOpenedAt: formatDistanceToNow(new Date("2023-03-03T00:00:00Z"), { addSuffix: true }),
+        mostRecentIssueOpenedAtISO8601: "2023-03-03T00:00:00Z",
+        oldestOpenIssueOpenedAt: formatDistanceToNow(new Date("2024-04-04T00:00:00Z"), { addSuffix: true }),
+        oldestOpenIssueOpenedAtISO8601: "2024-04-04T00:00:00Z",
+        languageColor: "rose",
+      },
+      {
+        name: "repo2",
+        description: "description2",
+        updatedAt: new Date("2021-01-01T00:00:00Z").toLocaleDateString(),
+        updatedAtISO8601: "2021-01-01T00:00:00Z",
+        htmlUrl: "http://url.com/repo2",
+        apiUrl: "http://api.com/repo2",
+        pullsUrl: "http://api.com/repo2/pulls",
+        issuesUrl: "http://api.com/repo2/issues",
+        language: "TypeScript",
+        topics: [],
+        openIssues: 0,
+        dependencies: [],
+        mostRecentPrOpenedAt: formatDistanceToNow(new Date("2021-01-01T00:00:00Z"), { addSuffix: true }),
+        mostRecentPrOpenedAtISO8601: "2021-01-01T00:00:00Z",
+        oldestOpenPrOpenedAt: formatDistanceToNow(new Date("2022-02-02T00:00:00Z"), { addSuffix: true }),
+        oldestOpenPrOpenedAtISO8601: "2022-02-02T00:00:00Z",
+        mostRecentIssueOpenedAt: formatDistanceToNow(new Date("2023-03-03T00:00:00Z"), { addSuffix: true }),
+        mostRecentIssueOpenedAtISO8601: "2023-03-03T00:00:00Z",
+        oldestOpenIssueOpenedAt: formatDistanceToNow(new Date("2024-04-04T00:00:00Z"), { addSuffix: true }),
+        oldestOpenIssueOpenedAtISO8601: "2024-04-04T00:00:00Z",
+        languageColor: "emerald",
       },
     ];
 
@@ -276,3 +371,59 @@ describe("mapRepoFromStorageToUi", () => {
     });
   });
 });
+
+describe("hashToTailwindColor", () => {
+  it("returns undefined if not given a string", () => {
+    const actual = hashToTailwindColor(5);
+
+    expect.strictEqual(actual, undefined);
+  });
+
+  it("hashes a string's characters and uses the hash to pick from the list of Tailwind colours", () => {
+    const inputStrings = [
+      "f",
+      "fo",
+      "foi",
+      "foic",
+      "foicn",
+      "foicnh",
+      "foicnhb",
+      "foicnhbm",
+      "foicnhbmg",
+      "foicnhbmga",
+      "foicnhbmgal",
+      "foicnhbmgalf",
+      "l",
+      "lk",
+      "lke",
+      "lkep",
+      "lkepj",
+    ];
+
+    const expectedStrings = [
+      "red",
+      "orange",
+      "amber",
+      "yellow",
+      "lime",
+      "green",
+      "emerald",
+      "teal",
+      "cyan",
+      "sky",
+      "blue",
+      "indigo",
+      "violet",
+      "purple",
+      "fuchsia",
+      "pink",
+      "rose",
+    ];
+
+    for (const [input, expected] of inputStrings.map((e, i) => [e, expectedStrings[i]])) {
+      const actual = hashToTailwindColor(input);
+
+      expect.strictEqual(actual, expected);
+    }
+  });
+})


### PR DESCRIPTION
This introduces various graphical improvements to the display of information within the Towtruck dashboard:

- The up/down arrow icons in the sortable column headers are now more predictably positioned.
- The headers for the table of repositories will now stick to the top of the screen during scrolling.
- Repository tags are now displayed in small capsules, similar to how they display on GitHub.
- Languages are now displayed in a colour-coded emblem next to the repository name.
- Dependabot alert counts are now displayed next to the language emblem/repository name.
- The `<h2>` tag intended to display the organisation name at the top of the dashboard has been fixed.
- The contents of cells in sortable columns will stick near the top of the screen during scrolling so that this information is still visible when large dependency lists are expanded.
- Table columns have been changed to a fixed width to make the layout more visually predictable when the content changes.

Example:
<img width="1708" alt="image" src="https://github.com/user-attachments/assets/354a6c33-885d-4236-b714-5b4a4b91aaeb">
