### PR TITLE
Implement GitHub webhooks

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -23,6 +23,13 @@ jobs:
         run: npx playwright install --with-deps
       - name: Run Playwright tests
         run: npx playwright test
+        env:
+          APP_ID: ${{ secrets.APP_ID }}
+          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+          CLIENT_ID: ${{ secrets.CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
+          WEBHOOK_SECRET: ${{ secrets.WEBHOOK_SECRET }}
+          REDIRECT_URL_BASE: ${{ secrets.REDIRECT_URL_BASE }}
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/db/index.js
+++ b/db/index.js
@@ -31,6 +31,7 @@ export class TowtruckDatabase {
   #getStatement;
   #getAllForNameStatement;
   #getAllForScopeStatement;
+  #deleteAllForScopeStatement;
 
   constructor(filename = "./data/towtruck.db", options) {
     this.#db = initialiseDatabase(filename, options);
@@ -39,6 +40,7 @@ export class TowtruckDatabase {
     this.#getStatement = this.#db.prepare("SELECT value FROM towtruck_data WHERE scope = ? AND name = ? AND key = ?;");
     this.#getAllForNameStatement = this.#db.prepare("SELECT key, value FROM towtruck_data WHERE scope = ? AND name = ?;");
     this.#getAllForScopeStatement = this.#db.prepare("SELECT name, key, value FROM towtruck_data WHERE scope = ?;");
+    this.#deleteAllForScopeStatement = this.#db.prepare("DELETE FROM towtruck_data WHERE scope = ?;");
   }
 
   #save(scope, name, key, data) {
@@ -75,6 +77,10 @@ export class TowtruckDatabase {
     return result;
   }
 
+  #deleteAllForScope(scope) {
+    return this.#deleteAllForScopeStatement.run(scope);
+  }
+
   saveToRepository(name, key, data) {
     return this.#save("repository", name, key, data);
   }
@@ -91,6 +97,10 @@ export class TowtruckDatabase {
     return this.#getAllForScope("repository");
   }
 
+  deleteAllRepositories() {
+    return this.#deleteAllForScope("repository");
+  }
+
   saveToDependency(name, key, data) {
     return this.#save("dependency", name, key, data);
   }
@@ -105,6 +115,10 @@ export class TowtruckDatabase {
 
   getAllDependencies() {
     return this.#getAllForScope("dependency");
+  }
+
+  deleteAllDependencies() {
+    return this.#deleteAllForScope("dependency");
   }
 
   transaction(fn) {

--- a/db/index.test.js
+++ b/db/index.test.js
@@ -228,6 +228,43 @@ describe("TowtruckDatabase", () => {
     });
   });
 
+  describe("deleteAllRepositories", () => {
+    it("removes the expected data from the table", () => {
+      const db = new TowtruckDatabase(testDbPath);
+
+      const insertStatement = new Database(testDbPath).prepare("INSERT INTO towtruck_data (scope, name, key, value) VALUES (?, ?, ?, ?);");
+      const selectStatement = new Database(testDbPath).prepare("SELECT COUNT(*) FROM towtruck_data WHERE scope = 'repository';");
+
+      const testRepoSomeData = {
+        array: [1, 2, 3],
+        text: "Text",
+        object: {
+          boolean: true,
+          missing: null,
+        },
+      };
+
+      const testRepoSomeOtherData = {
+        foo: "bar",
+        baz: false,
+        quux: 0.123456789,
+      };
+
+      const anotherRepoSomeData = [1, "foo", true, null];
+
+      insertStatement.run("repository", "test-repo", "some-data", JSON.stringify(testRepoSomeData));
+      insertStatement.run("repository", "test-repo", "some-other-data", JSON.stringify(testRepoSomeOtherData));
+      insertStatement.run("repository", "another-repo", "some-data", JSON.stringify(anotherRepoSomeData));
+      insertStatement.run("dependency", "test-dependency", "some-data", JSON.stringify({}));
+
+      db.deleteAllRepositories();
+
+      const actual = selectStatement.get();
+
+      expect.deepStrictEqual(actual, { "COUNT(*)": 0 });
+    });
+  });
+
   describe("saveToDependency", () => {
     it("inserts the expected data into the table", () => {
       const db = new TowtruckDatabase(testDbPath);
@@ -413,6 +450,43 @@ describe("TowtruckDatabase", () => {
       const actual = db.getAllDependencies();
 
       expect.deepStrictEqual(actual, {});
+    });
+  });
+
+  describe("deleteAllDependencies", () => {
+    it("removes the expected data from the table", () => {
+      const db = new TowtruckDatabase(testDbPath);
+
+      const insertStatement = new Database(testDbPath).prepare("INSERT INTO towtruck_data (scope, name, key, value) VALUES (?, ?, ?, ?);");
+      const selectStatement = new Database(testDbPath).prepare("SELECT COUNT(*) FROM towtruck_data WHERE scope = 'dependency';");
+
+      const testDepSomeData = {
+        array: [1, 2, 3],
+        text: "Text",
+        object: {
+          boolean: true,
+          missing: null,
+        },
+      };
+
+      const testDepSomeOtherData = {
+        foo: "bar",
+        baz: false,
+        quux: 0.123456789,
+      };
+
+      const anotherDepSomeData = [1, "foo", true, null];
+
+      insertStatement.run("dependency", "test-dep", "some-data", JSON.stringify(testDepSomeData));
+      insertStatement.run("dependency", "test-dep", "some-other-data", JSON.stringify(testDepSomeOtherData));
+      insertStatement.run("dependency", "another-dep", "some-data", JSON.stringify(anotherDepSomeData));
+      insertStatement.run("repository", "test-repository", "some-data", JSON.stringify({}));
+
+      db.deleteAllDependencies();
+
+      const actual = selectStatement.get();
+
+      expect.deepStrictEqual(actual, { "COUNT(*)": 0 });
     });
   });
 });

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ import { mapRepoFromStorageToUi } from "./utils/index.js";
 import { getQueryParams } from "./utils/queryParams.js";
 import { sortByType } from "./utils/sorting.js";
 import { TowtruckDatabase } from "./db/index.js";
+import { handleWebhooks } from "./webhooks/index.js";
 
 nunjucks.configure({
   autoescape: true,
@@ -11,6 +12,8 @@ nunjucks.configure({
 });
 
 const httpServer = createServer(async (request, response) => {
+  if (await handleWebhooks(request, response)) return;
+
   const url = new URL(request.url, `http://${request.headers.host}`);
 
   if (url.pathname !== "/") {

--- a/octokitApp.js
+++ b/octokitApp.js
@@ -1,4 +1,4 @@
-import { App, createNodeMiddleware } from "@octokit/app";
+import { App } from "@octokit/app";
 
 const APP_ID = process.env.APP_ID;
 const PRIVATE_KEY = process.env.PRIVATE_KEY;
@@ -20,10 +20,4 @@ const app = new App({
   },
 });
 
-app.webhooks.onAny(({ name }) => {
-  console.log(name, "event received");
-});
-
-const middleware = createNodeMiddleware(app);
-
-export const OctokitApp = { app, middleware };
+export const OctokitApp = { app };

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "seed": "npm run seed:repos && npm run seed:lifetimes",
-    "seed:repos": "node --env-file=.env ./utils/githubApi/fetchAllRepos.js",
-    "seed:lifetimes": "node --env-file=.env ./utils/endOfLifeDateApi/fetchAllDependencyEolInfo.js"
+    "seed:repos": "node --env-file=.env ./seed/repos.js",
+    "seed:lifetimes": "node --env-file=.env ./seed/lifetimes.js"
   },
   "author": "dxw",
   "license": "MIT",

--- a/seed/lifetimes.js
+++ b/seed/lifetimes.js
@@ -1,0 +1,20 @@
+import { TowtruckDatabase } from "../db/index.js";
+import {
+  fetchAllDependencyLifetimes,
+  saveAllDependencyLifetimes,
+} from "../utils/endOfLifeDateApi/fetchAllDependencyEolInfo.js";
+import { EndOfLifeDateApiClient } from "../utils/endOfLifeDateApi/index.js";
+
+const seed = async () => {
+  const db = new TowtruckDatabase();
+
+  db.deleteAllDependencies();
+
+  const allLifetimes = await fetchAllDependencyLifetimes(
+    db,
+    new EndOfLifeDateApiClient(),
+  );
+  await saveAllDependencyLifetimes(allLifetimes, db);
+};
+
+await seed();

--- a/seed/repos.js
+++ b/seed/repos.js
@@ -1,0 +1,34 @@
+import { TowtruckDatabase } from "../db/index.js";
+import {
+  fetchForRepo,
+  saveAllRepos,
+} from "../utils/githubApi/fetchAllRepos.js";
+import { OctokitApp } from "../octokitApp.js";
+
+/**
+ * Fetches all repos from the GitHub API.
+ * Each repo is enriched with data fetched through further API calls
+ * @returns {Promise<StoredRepo[]>}
+ */
+const fetchAllRepos = async () => {
+  const repos = [];
+
+  await OctokitApp.app.eachRepository(async ({ repository, octokit }) => {
+    const repo = await fetchForRepo(repository, octokit);
+
+    if (repo) repos.push(repo);
+  });
+
+  return repos;
+};
+
+const seed = async () => {
+  const db = new TowtruckDatabase();
+
+  db.deleteAllRepositories();
+
+  const allRepos = await fetchAllRepos();
+  saveAllRepos(allRepos, db);
+};
+
+await seed();

--- a/utils/endOfLifeDateApi/fetchAllDependencyEolInfo.js
+++ b/utils/endOfLifeDateApi/fetchAllDependencyEolInfo.js
@@ -44,7 +44,7 @@ const fetchAllDependencyLifetimes = async () => {
 /**
  * Saves all lifetime information for all repository dependencies to a JSON file.
  */
-const saveAllDependencyLifetimes = async () => {
+export const saveAllDependencyLifetimes = async () => {
   console.info("Fetching all dependency EOL info...");
   const allLifetimes = await fetchAllDependencyLifetimes();
 

--- a/utils/endOfLifeDateApi/fetchAllDependencyEolInfo.test.js
+++ b/utils/endOfLifeDateApi/fetchAllDependencyEolInfo.test.js
@@ -1,0 +1,174 @@
+import { describe, it } from "node:test";
+import expect from "node:assert";
+import {
+  fetchAllDependencyLifetimes,
+  saveAllDependencyLifetimes,
+} from "./fetchAllDependencyEolInfo.js";
+
+const db = {
+  getAllRepositories: () => ({}),
+  transaction: (fn) => {
+    return (arg) => fn(arg);
+  },
+  saveToDependency: () => {},
+};
+const apiClient = {
+  getAllCycles: (dependency) => ({ dependency, cycles: [] }),
+};
+
+describe("fetchAllDependencyLifetimes", () => {
+  it("should return information only for dependencies for which the endoflife.date API has information", async (t) => {
+    const repositories = {
+      repo1: {
+        dependencies: [
+          {
+            name: "foobar",
+          },
+          {
+            name: "libquux",
+          },
+        ],
+      },
+    };
+
+    const cycles = {
+      foobar: [
+        {
+          cycle: "1.2",
+          latestVersion: "1.2.3",
+          releaseDate: "2024-01-01",
+        },
+      ],
+    };
+
+    t.mock.method(db, "getAllRepositories", () => repositories);
+    t.mock.method(apiClient, "getAllCycles", (dependency) => {
+      if (cycles[dependency]) {
+        return { dependency, cycles: cycles[dependency] };
+      } else {
+        return { message: "Product not found" };
+      }
+    });
+
+    const expected = [
+      {
+        dependency: "foobar",
+        lifetimes: {
+          dependency: "foobar",
+          cycles: cycles.foobar,
+        },
+      },
+    ];
+
+    const actual = await fetchAllDependencyLifetimes(db, apiClient);
+
+    expect.deepStrictEqual(actual, expected);
+  });
+
+  it("should avoid duplicate results", async (t) => {
+    const repositories = {
+      repo1: {
+        dependencies: [
+          {
+            name: "foobar",
+          },
+        ],
+      },
+      repo2: {
+        dependencies: [
+          {
+            name: "foobar",
+          },
+        ],
+      },
+    };
+
+    const cycles = {
+      foobar: [
+        {
+          cycle: "1.2",
+          latestVersion: "1.2.3",
+          releaseDate: "2024-01-01",
+        },
+      ],
+    };
+
+    t.mock.method(db, "getAllRepositories", () => repositories);
+    t.mock.method(apiClient, "getAllCycles", (dependency) => {
+      if (cycles[dependency]) {
+        return { dependency, cycles: cycles[dependency] };
+      } else {
+        return { message: "Product not found" };
+      }
+    });
+
+    const expected = [
+      {
+        dependency: "foobar",
+        lifetimes: {
+          dependency: "foobar",
+          cycles: cycles.foobar,
+        },
+      },
+    ];
+
+    const actual = await fetchAllDependencyLifetimes(db, apiClient);
+
+    expect.deepStrictEqual(actual, expected);
+  });
+});
+
+describe("saveAllDependencyLifetimes", () => {
+  it("should save the expected lifetime information", async (t) => {
+    t.mock.method(db, "transaction");
+    t.mock.method(db, "saveToDependency");
+
+    const dependency1 = {
+      dependency: "foobar",
+      lifetimes: {
+        dependency: "foobar",
+        cycles: [
+          {
+            cycle: "1.2",
+            latestVersion: "1.2.3",
+            releaseDate: "2024-01-01",
+          },
+        ],
+      },
+    };
+
+    const dependency2 = {
+      dependency: "libquux",
+      lifetimes: {
+        dependency: "libquux",
+        cycles: [
+          {
+            cycle: "4.4",
+          },
+          {
+            cycle: "4.3",
+          },
+        ],
+      },
+    };
+
+    const allLifetimes = [dependency1, dependency2];
+
+    await saveAllDependencyLifetimes(allLifetimes, db);
+
+    expect.strictEqual(db.transaction.mock.callCount(), 1);
+
+    expect.strictEqual(db.saveToDependency.mock.callCount(), 2);
+
+    expect.deepStrictEqual(db.saveToDependency.mock.calls[0].arguments, [
+      dependency1.dependency,
+      "lifetimes",
+      dependency1.lifetimes,
+    ]);
+    expect.deepStrictEqual(db.saveToDependency.mock.calls[1].arguments, [
+      dependency2.dependency,
+      "lifetimes",
+      dependency2.lifetimes,
+    ]);
+  });
+});

--- a/utils/githubApi/fetchAllRepos.js
+++ b/utils/githubApi/fetchAllRepos.js
@@ -1,65 +1,68 @@
-import { OctokitApp } from "../../octokitApp.js";
 import { mapRepoFromApiForStorage } from "../index.js";
 import { getDependenciesForRepo } from "../renovate/dependencyDashboard.js";
 import { getOpenPRsForRepo } from "./fetchOpenPrs.js";
 import { getOpenIssuesForRepo } from "./fetchOpenIssues.js";
 import { getDependabotAlertsForRepo } from "./fetchDependabotAlerts.js";
-import { TowtruckDatabase } from "../../db/index.js";
 
 /**
  * @typedef {import('../index.js').StoredRepo} StoredRepo
+ * @typedef {import("../../model/Dependency.js").Dependency} Dependency
+ * @typedef {import("../../db/index.js").TowtruckDatabase} TowtruckDatabase
+ * @typedef {import("@octokit/types/dist-types/index.js").Endpoints["GET /installation/repositories"]["response"]["data"]["repositories"][0]} Repository
+ * @typedef {import("@octokit/core/dist-types/index.js").Octokit} Octokit
  */
 
 /**
- * Fetches all repos from the GitHub API.
- * Each repo is enriched with data fetched through further API calls
- * @returns {Promise<StoredRepo[]>}
+ * @typedef {Object} RepoData
+ * @property {StoredRepo} repo
+ * @property {Dependency[]} dependencies
+ * @property {Object} prInfo
+ * @property {Object} issueInfo
+ * @property {Object} alerts
  */
-const fetchAllRepos = async () => {
-  const repos = [];
 
-  await OctokitApp.app.eachRepository(async ({ repository, octokit }) => {
-    if (repository.archived) return;
+/**
+ *
+ * @param {Repository} repository
+ * @param {Octokit} octokit
+ * @returns {Promise<RepoData>}
+ */
+export const fetchForRepo = async (repository, octokit) => {
+  if (repository.archived) return;
 
-    let repo = mapRepoFromApiForStorage(repository);
+  let repo = mapRepoFromApiForStorage(repository);
 
-    await Promise.all([
-      getDependenciesForRepo({
-        repository,
-        octokit,
-      }),
-      getOpenPRsForRepo({
-        repository,
-        octokit,
-      }),
-      getOpenIssuesForRepo({
-        repository,
-        octokit,
-      }),
-      getDependabotAlertsForRepo({
-        repository,
-        octokit,
-      }),
-    ]).then(([dependencies, prInfo, issueInfo, alerts]) => {
-      repo = { repo, dependencies, prInfo, issueInfo, alerts };
-    });
-
-    repos.push(repo);
+  await Promise.all([
+    getDependenciesForRepo({
+      repository,
+      octokit,
+    }),
+    getOpenPRsForRepo({
+      repository,
+      octokit,
+    }),
+    getOpenIssuesForRepo({
+      repository,
+      octokit,
+    }),
+    getDependabotAlertsForRepo({
+      repository,
+      octokit,
+    }),
+  ]).then(([dependencies, prInfo, issueInfo, alerts]) => {
+    repo = { repo, dependencies, prInfo, issueInfo, alerts };
   });
 
-  return repos;
+  return repo;
 };
 
 /**
- * Saves all repos to a JSON file
+ *
+ * @param {RepoData[]} allRepos
+ * @param {TowtruckDatabase} db
  */
-const saveAllRepos = async () => {
-  console.info("Fetching all repos...");
-  const allRepos = await fetchAllRepos();
-
+export const saveAllRepos = async (allRepos, db) => {
   try {
-    const db = new TowtruckDatabase();
-
     console.info("Saving all repos...");
     const saveAllRepos = db.transaction((repos) => {
       repos.forEach((repo) => {
@@ -79,5 +82,3 @@ const saveAllRepos = async () => {
     console.error("Error saving all repos", error);
   }
 };
-
-await saveAllRepos();

--- a/utils/githubApi/fetchAllRepos.test.js
+++ b/utils/githubApi/fetchAllRepos.test.js
@@ -1,0 +1,388 @@
+import { describe, it } from "node:test";
+import expect from "node:assert";
+import { fetchForRepo, saveAllRepos } from "./fetchAllRepos.js";
+import { Dependency } from "../../model/Dependency.js";
+
+const octokit = {
+  request: async () => {
+    return Promise.resolve({});
+  },
+};
+
+const db = {
+  transaction: (fn) => {
+    return (arg) => fn(arg);
+  },
+  saveToRepository: () => {},
+};
+
+describe("fetchForRepo", () => {
+  it("should map core repository information", async (t) => {
+    const responses = {
+      "https://some.api/issues": {
+        data: [],
+      },
+      "https://some.api/pulls": {
+        data: [],
+      },
+    };
+
+    t.mock.method(octokit, "request", async (url) =>
+      Promise.resolve(responses[url]),
+    );
+
+    const repository = {
+      name: "repo",
+      description: "Some repo",
+      owner: {
+        login: "dxw",
+      },
+      url: "https://some.api/dxw/repo",
+      html_url: "https://some.site/dxw/repo",
+      issues_url: "https://some.api/issues",
+      pulls_url: "https://some.api/pulls",
+      updated_at: "2024-01-01T12:34:56.789Z",
+      language: "Ruby",
+      topics: ["foo", "bar"],
+      open_issues: 4,
+    };
+
+    const expected = {
+      name: "repo",
+      owner: "dxw",
+      description: "Some repo",
+      htmlUrl: "https://some.site/dxw/repo",
+      apiUrl: "https://some.api/dxw/repo",
+      pullsUrl: "https://some.api/pulls",
+      issuesUrl: "https://some.api/issues",
+      updatedAt: "2024-01-01T12:34:56.789Z",
+      language: "Ruby",
+      topics: ["foo", "bar"],
+      openIssues: 4,
+    };
+
+    const actual = await fetchForRepo(repository, octokit);
+
+    expect.deepStrictEqual(actual.repo, expected);
+  });
+
+  it("should fetch dependency information", async (t) => {
+    const responses = {
+      "https://some.api/issues": {
+        data: [
+          {
+            user: {
+              login: "renovate[bot]",
+            },
+            body: "## Detected dependencies\n\n- `foobar 1.2.3`\n- `libquux 0.1.1-alpha` \n\n---",
+          },
+        ],
+      },
+      "https://some.api/pulls": {
+        data: [],
+      },
+    };
+
+    t.mock.method(octokit, "request", async (url) =>
+      Promise.resolve(responses[url]),
+    );
+
+    const repository = {
+      name: "repo",
+      owner: {
+        login: "dxw",
+      },
+      issues_url: "https://some.api/issues",
+      pulls_url: "https://some.api/pulls",
+    };
+
+    const expected = [
+      new Dependency("foobar", "1.2.3"),
+      new Dependency("libquux", "0.1.1-alpha"),
+    ];
+
+    const actual = await fetchForRepo(repository, octokit);
+
+    expect.deepStrictEqual(actual.dependencies, expected);
+  });
+
+  it("should fetch open pull request information", async (t) => {
+    const responses = {
+      "https://some.api/issues": {
+        data: [],
+      },
+      "https://some.api/pulls": {
+        data: [
+          {
+            user: {
+              login: "renovate[bot]",
+            },
+            created_at: "2024-10-10T11:22:33.444Z",
+            state: "open",
+          },
+          {
+            user: {
+              login: "foo",
+            },
+            created_at: "2024-01-01T12:34:56.789Z",
+            state: "open",
+          },
+        ],
+      },
+    };
+
+    t.mock.method(octokit, "request", async (url) =>
+      Promise.resolve(responses[url]),
+    );
+
+    const repository = {
+      name: "repo",
+      description: "Some repo",
+      owner: {
+        login: "dxw",
+      },
+      url: "https://some.api/dxw/repo",
+      html_url: "https://some.site/dxw/repo",
+      issues_url: "https://some.api/issues",
+      pulls_url: "https://some.api/pulls",
+      updated_at: "2024-01-01T12:34:56.789Z",
+      language: "Ruby",
+      topics: ["foo", "bar"],
+      open_issues: 4,
+    };
+
+    const expected = {
+      openPrCount: 2,
+      openBotPrCount: 1,
+      oldestOpenPrOpenedAt: new Date("2024-01-01T12:34:56.789Z"),
+      mostRecentPrOpenedAt: new Date("2024-10-10T11:22:33.444Z"),
+    };
+
+    const actual = await fetchForRepo(repository, octokit);
+
+    expect.deepStrictEqual(actual.prInfo, expected);
+  });
+
+  it("should fetch open issue information", async (t) => {
+    const responses = {
+      "https://some.api/issues": {
+        data: [
+          {
+            user: {
+              login: "foo",
+            },
+            created_at: "2024-01-01T12:34:56.789Z",
+            state: "open",
+          },
+          {
+            user: {
+              login: "bar",
+            },
+            created_at: "2024-10-10T11:22:33.444Z",
+            state: "open",
+          },
+        ],
+      },
+      "https://some.api/pulls": {
+        data: [],
+      },
+    };
+
+    t.mock.method(octokit, "request", async (url) =>
+      Promise.resolve(responses[url]),
+    );
+
+    const repository = {
+      name: "repo",
+      owner: {
+        login: "dxw",
+      },
+      issues_url: "https://some.api/issues",
+      pulls_url: "https://some.api/pulls",
+    };
+
+    const expected = {
+      oldestOpenIssueOpenedAt: new Date("2024-01-01T12:34:56.789Z"),
+      mostRecentIssueOpenedAt: new Date("2024-10-10T11:22:33.444Z"),
+    };
+
+    const actual = await fetchForRepo(repository, octokit);
+
+    expect.deepStrictEqual(actual.issueInfo, expected);
+  });
+
+  it("should fetch Dependabot vulnerability information", async (t) => {
+    const responses = {
+      "https://some.api/issues": {
+        data: [],
+      },
+      "https://some.api/pulls": {
+        data: [],
+      },
+      "/repos/{owner}/{repo}/dependabot/alerts": {
+        data: [
+          {
+            state: "open",
+            security_vulnerability: {
+              severity: "critical",
+            },
+          },
+          {
+            state: "open",
+            security_vulnerability: {
+              severity: "high",
+            },
+          },
+          {
+            state: "open",
+            security_vulnerability: {
+              severity: "medium",
+            },
+          },
+          {
+            state: "open",
+            security_vulnerability: {
+              severity: "low",
+            },
+          },
+        ],
+      },
+    };
+
+    t.mock.method(octokit, "request", async (url) =>
+      Promise.resolve(responses[url]),
+    );
+
+    const repository = {
+      name: "repo",
+      owner: {
+        login: "dxw",
+      },
+      issues_url: "https://some.api/issues",
+      pulls_url: "https://some.api/pulls",
+    };
+
+    const expected = {
+      criticalSeverityAlerts: 1,
+      highSeverityAlerts: 1,
+      mediumSeverityAlerts: 1,
+      lowSeverityAlerts: 1,
+      totalOpenAlerts: 4,
+    };
+
+    const actual = await fetchForRepo(repository, octokit);
+
+    expect.deepStrictEqual(actual.alerts, expected);
+  });
+});
+
+describe("saveAllRepos", () => {
+  it("should save the expected repository information", async (t) => {
+    t.mock.method(db, "transaction");
+    t.mock.method(db, "saveToRepository");
+
+    const repo1 = {
+      repo: {
+        name: "repo1",
+        owner: "dxw",
+      },
+      dependencies: ["foo"],
+      prInfo: {
+        openPrCount: 1,
+      },
+      issueInfo: {
+        openIssueCount: 2,
+      },
+      alerts: {
+        totalOpenAlerts: 4,
+      },
+    };
+
+    const repo2 = {
+      repo: {
+        name: "repo2",
+        owner: "dxw",
+      },
+      dependencies: ["bar"],
+      prInfo: {
+        openPrCount: 0,
+      },
+      issueInfo: {
+        openIssueCount: 3,
+      },
+      alerts: {
+        totalOpenAlerts: 2,
+      },
+    };
+
+    const allRepos = [repo1, repo2];
+
+    await saveAllRepos(allRepos, db);
+
+    expect.strictEqual(db.transaction.mock.callCount(), 1);
+
+    expect.strictEqual(db.saveToRepository.mock.callCount(), 12);
+
+    expect.deepStrictEqual(db.saveToRepository.mock.calls[0].arguments, [
+      repo1.repo.name,
+      "main",
+      repo1.repo,
+    ]);
+    expect.deepStrictEqual(db.saveToRepository.mock.calls[1].arguments, [
+      repo1.repo.name,
+      "owner",
+      repo1.repo.owner,
+    ]);
+    expect.deepStrictEqual(db.saveToRepository.mock.calls[2].arguments, [
+      repo1.repo.name,
+      "dependencies",
+      repo1.dependencies,
+    ]);
+    expect.deepStrictEqual(db.saveToRepository.mock.calls[3].arguments, [
+      repo1.repo.name,
+      "pullRequests",
+      repo1.prInfo,
+    ]);
+    expect.deepStrictEqual(db.saveToRepository.mock.calls[4].arguments, [
+      repo1.repo.name,
+      "issues",
+      repo1.issueInfo,
+    ]);
+    expect.deepStrictEqual(db.saveToRepository.mock.calls[5].arguments, [
+      repo1.repo.name,
+      "dependabotAlerts",
+      repo1.alerts,
+    ]);
+
+    expect.deepStrictEqual(db.saveToRepository.mock.calls[6].arguments, [
+      repo2.repo.name,
+      "main",
+      repo2.repo,
+    ]);
+    expect.deepStrictEqual(db.saveToRepository.mock.calls[7].arguments, [
+      repo2.repo.name,
+      "owner",
+      repo2.repo.owner,
+    ]);
+    expect.deepStrictEqual(db.saveToRepository.mock.calls[8].arguments, [
+      repo2.repo.name,
+      "dependencies",
+      repo2.dependencies,
+    ]);
+    expect.deepStrictEqual(db.saveToRepository.mock.calls[9].arguments, [
+      repo2.repo.name,
+      "pullRequests",
+      repo2.prInfo,
+    ]);
+    expect.deepStrictEqual(db.saveToRepository.mock.calls[10].arguments, [
+      repo2.repo.name,
+      "issues",
+      repo2.issueInfo,
+    ]);
+    expect.deepStrictEqual(db.saveToRepository.mock.calls[11].arguments, [
+      repo2.repo.name,
+      "dependabotAlerts",
+      repo2.alerts,
+    ]);
+  });
+});

--- a/webhooks/alerts.js
+++ b/webhooks/alerts.js
@@ -1,0 +1,31 @@
+import { TowtruckDatabase } from "../db/index.js";
+import { getDependabotAlertsForRepo } from "../utils/githubApi/fetchDependabotAlerts.js";
+
+/**
+ * @typedef {import("./index.js").Event<T>} Event<T>
+ * @template {string} T
+ */
+
+/**
+ * @param {Event<"dependabot_alert">} event
+ * @param {TowtruckDatabase} db
+ */
+export const handleEvent = async ({ payload, octokit }, db) => {
+  const alerts = await getDependabotAlertsForRepo({
+    octokit,
+    repository: payload.repository,
+  });
+
+  db.saveToRepository(payload.repository.name, "dependabotAlerts", alerts);
+};
+
+/**
+ * Handles the `"dependabot_alert"` webhook event.
+ * @param {Event<"dependabot_alert">} event
+ */
+export const onDependabotAlert = async (event) => {
+  console.log(
+    `Dependabot alert #${event.payload.alert.number} in ${event.payload.repository.name} updated: ${event.payload.action}`,
+  );
+  handleEvent(event, new TowtruckDatabase());
+};

--- a/webhooks/alerts.test.js
+++ b/webhooks/alerts.test.js
@@ -1,0 +1,87 @@
+import { describe, it } from "node:test";
+import expect from "node:assert";
+import { handleEvent } from "./alerts.js";
+
+const db = {
+  saveToRepository: () => {},
+};
+
+const octokit = {
+  request: async () => {
+    return Promise.resolve({});
+  },
+};
+
+describe("handleEvent", () => {
+  it("should update the Dependabot alert information in the database for the repository", async (t) => {
+    const responses = {
+      "/repos/{owner}/{repo}/dependabot/alerts": {
+        data: [
+          {
+            state: "open",
+            security_vulnerability: {
+              severity: "critical",
+            },
+          },
+          {
+            state: "open",
+            security_vulnerability: {
+              severity: "high",
+            },
+          },
+          {
+            state: "open",
+            security_vulnerability: {
+              severity: "medium",
+            },
+          },
+          {
+            state: "open",
+            security_vulnerability: {
+              severity: "low",
+            },
+          },
+        ],
+      },
+    };
+
+    t.mock.method(octokit, "request", async (url) =>
+      Promise.resolve(responses[url]),
+    );
+    t.mock.method(db, "saveToRepository");
+
+    const payload = {
+      repository: {
+        name: "repo",
+        owner: {
+          login: "dxw",
+        },
+      },
+    };
+
+    const event = {
+      payload,
+      octokit,
+    };
+
+    const expected = {
+      criticalSeverityAlerts: 1,
+      highSeverityAlerts: 1,
+      mediumSeverityAlerts: 1,
+      lowSeverityAlerts: 1,
+      totalOpenAlerts: 4,
+    };
+
+    await handleEvent(event, db);
+
+    expect.strictEqual(octokit.request.mock.callCount(), 1);
+
+    expect.strictEqual(db.saveToRepository.mock.callCount(), 1);
+
+    expect.deepStrictEqual(db.saveToRepository.mock.calls[0].arguments, [
+      payload.repository.name,
+      "dependabotAlerts",
+      expected,
+    ]);
+  });
+});

--- a/webhooks/dependencies.js
+++ b/webhooks/dependencies.js
@@ -1,0 +1,64 @@
+import { TowtruckDatabase } from "../db/index.js";
+import {
+  fetchAllDependencyLifetimes,
+  saveAllDependencyLifetimes,
+} from "../utils/endOfLifeDateApi/fetchAllDependencyEolInfo.js";
+import { EndOfLifeDateApiClient } from "../utils/endOfLifeDateApi/index.js";
+import { getDependenciesForRepo } from "../utils/renovate/dependencyDashboard.js";
+
+/**
+ * @typedef {import("./index.js").Event<T>} Event<T>
+ * @template {string} T
+ */
+
+/**
+ * @param {Event<"push" | "issues.edited">} event
+ * @param {TowtruckDatabase} db
+ * @param {EndOfLifeDateApiClient} apiClient
+ */
+export const handleEvent = async ({ payload, octokit }, db, apiClient) => {
+  const dependencies = await getDependenciesForRepo({
+    octokit,
+    repository: payload.repository,
+  });
+
+  db.saveToRepository(payload.repository.name, "dependencies", dependencies);
+
+  const allLifetimes = await fetchAllDependencyLifetimes(db, apiClient);
+  await saveAllDependencyLifetimes(allLifetimes, db);
+};
+
+/**
+ * Handles the `"push"` webhook event.
+ * @param {Event<"push">} event
+ */
+export const onPush = async (event) => {
+  console.log(`Push to ${event.payload.repository.name}: ${event.payload.ref}`);
+  if (event.payload.ref === "refs/heads/main") {
+    return await handleEvent(
+      event,
+      new TowtruckDatabase(),
+      new EndOfLifeDateApiClient(),
+    );
+  }
+};
+
+/**
+ * Handles the `"issues.edited"` webhook event.
+ * @param {Event<"issues.edited">} event
+ */
+export const onIssueEdited = async (event) => {
+  console.log(
+    `Issue #${event.payload.issue.number} updated in ${event.payload.repository.name}: ${event.payload.issue.title}`,
+  );
+  if (
+    event.payload.issue.user.login === "renovate[bot]" &&
+    event.payload.issue.pull_request === undefined
+  ) {
+    return await handleEvent(
+      event,
+      new TowtruckDatabase(),
+      new EndOfLifeDateApiClient(),
+    );
+  }
+};

--- a/webhooks/dependencies.test.js
+++ b/webhooks/dependencies.test.js
@@ -1,0 +1,172 @@
+import { describe, it } from "node:test";
+import expect from "node:assert";
+import { handleEvent } from "./dependencies.js";
+import { Dependency } from "../model/Dependency.js";
+
+const db = {
+  transaction: (fn) => {
+    return (arg) => fn(arg);
+  },
+  saveToRepository: () => {},
+  saveToDependency: () => {},
+  getAllRepositories: () => {},
+};
+
+const octokit = {
+  request: async () => {
+    return Promise.resolve({});
+  },
+};
+
+const apiClient = {
+  getAllCycles: (dependency) => ({ dependency, cycles: [] }),
+};
+
+describe("handleEvent", () => {
+  it("should update the dependency information in the database for the repository", async (t) => {
+    const responses = {
+      "https://some.api/issues": {
+        data: [
+          {
+            user: {
+              login: "renovate[bot]",
+            },
+            body: "## Detected dependencies\n\n- `foobar 1.2.3`\n- `libquux 0.1.1-alpha` \n\n---",
+          },
+        ],
+      },
+    };
+
+    const repository = {
+      name: "repo",
+      owner: {
+        login: "dxw",
+      },
+      issues_url: "https://some.api/issues",
+    };
+
+    const repositories = {
+      repo: {
+        repository,
+        dependencies: [],
+      },
+    };
+
+    t.mock.method(octokit, "request", async (url) =>
+      Promise.resolve(responses[url]),
+    );
+    t.mock.method(db, "saveToRepository");
+    t.mock.method(db, "getAllRepositories", () => repositories);
+
+    const payload = {
+      repository,
+    };
+
+    const event = {
+      payload,
+      octokit,
+    };
+
+    const expected = [
+      new Dependency("foobar", "1.2.3"),
+      new Dependency("libquux", "0.1.1-alpha"),
+    ];
+
+    await handleEvent(event, db, apiClient);
+
+    expect.strictEqual(octokit.request.mock.callCount(), 1);
+
+    expect.strictEqual(db.saveToRepository.mock.callCount(), 1);
+
+    expect.deepStrictEqual(db.saveToRepository.mock.calls[0].arguments, [
+      payload.repository.name,
+      "dependencies",
+      expected,
+    ]);
+  });
+
+  it("should update the lifetime information stored in the database", async (t) => {
+    const responses = {
+      "https://some.api/issues": {
+        data: [
+          {
+            user: {
+              login: "renovate[bot]",
+            },
+            body: "## Detected dependencies\n\n- `foobar 1.2.3`\n- `libquux 0.1.1-alpha` \n\n---",
+          },
+        ],
+      },
+    };
+
+    const repository = {
+      name: "repo",
+      owner: {
+        login: "dxw",
+      },
+      issues_url: "https://some.api/issues",
+    };
+
+    const repositories = {
+      repo: {
+        repository,
+        dependencies: [new Dependency("foobar", "1.2.3")],
+      },
+    };
+
+    const cycles = {
+      foobar: [
+        {
+          cycle: "1.2",
+          latestVersion: "1.2.3",
+          releaseDate: "2024-01-01",
+        },
+      ],
+    };
+
+    t.mock.method(octokit, "request", async (url) =>
+      Promise.resolve(responses[url]),
+    );
+    t.mock.method(db, "transaction");
+    t.mock.method(db, "saveToDependency");
+    t.mock.method(db, "getAllRepositories", () => repositories);
+    t.mock.method(apiClient, "getAllCycles", (dependency) => {
+      if (cycles[dependency]) {
+        return { dependency, cycles: cycles[dependency] };
+      } else {
+        return { message: "Product not found" };
+      }
+    });
+
+    const expected = [
+      {
+        dependency: "foobar",
+        lifetimes: {
+          dependency: "foobar",
+          cycles: cycles.foobar,
+        },
+      },
+    ];
+
+    const payload = {
+      repository,
+    };
+
+    const event = {
+      payload,
+      octokit,
+    };
+
+    await handleEvent(event, db, apiClient);
+
+    expect.strictEqual(apiClient.getAllCycles.mock.callCount(), 1);
+
+    expect.strictEqual(db.saveToDependency.mock.callCount(), 1);
+
+    expect.deepStrictEqual(db.saveToDependency.mock.calls[0].arguments, [
+      expected[0].dependency,
+      "lifetimes",
+      expected[0].lifetimes,
+    ]);
+  });
+});

--- a/webhooks/index.js
+++ b/webhooks/index.js
@@ -1,0 +1,38 @@
+import { createNodeMiddleware } from "@octokit/app";
+import { OctokitApp } from "../octokitApp.js";
+import { onPullRequestClosed, onPullRequestOpened } from "./pullRequests.js";
+import { onIssueClosed, onIssueOpened } from "./issues.js";
+import { onIssueEdited, onPush } from "./dependencies.js";
+import { onDependabotAlert } from "./alerts.js";
+import { onRepository } from "./repository.js";
+
+/**
+ * @typedef {import("@octokit/webhooks/dist-types/index").EmitterWebhookEvent<T>} EmitterWebhookEvent<T>
+ * @template {string} T
+ */
+
+/**
+ * @typedef {import("@octokit/core/dist-types/index").Octokit} Octokit
+ */
+
+/**
+ * @typedef {EmitterWebhookEvent<T> & { octokit: Octokit; }} Event<T>
+ * @template {string} T
+ */
+
+const registerWebhook = OctokitApp.app.webhooks.on;
+
+registerWebhook("pull_request.opened", onPullRequestOpened);
+registerWebhook("pull_request.closed", onPullRequestClosed);
+
+registerWebhook("issues.opened", onIssueOpened);
+registerWebhook("issues.closed", onIssueClosed);
+
+registerWebhook("push", onPush);
+registerWebhook("issues.edited", onIssueEdited);
+
+registerWebhook("dependabot_alert", onDependabotAlert);
+
+registerWebhook("repository", onRepository);
+
+export const handleWebhooks = createNodeMiddleware(OctokitApp.app);

--- a/webhooks/issues.js
+++ b/webhooks/issues.js
@@ -1,0 +1,42 @@
+import { TowtruckDatabase } from "../db/index.js";
+import { getOpenIssuesForRepo } from "../utils/githubApi/fetchOpenIssues.js";
+
+/**
+ * @typedef {import("./index.js").Event<T>} Event<T>
+ * @template {string} T
+ */
+
+/**
+ * @param {Event<"issues">} event
+ * @param {TowtruckDatabase} db
+ */
+export const handleEvent = async ({ payload, octokit }, db) => {
+  const issueInfo = await getOpenIssuesForRepo({
+    octokit,
+    repository: payload.repository,
+  });
+
+  db.saveToRepository(payload.repository.name, "issues", issueInfo);
+};
+
+/**
+ * Handles the `"issues.opened"` webhook event.
+ * @param {Event<"issues.opened">} event
+ */
+export const onIssueOpened = async (event) => {
+  console.log(
+    `New issue #${event.payload.issue.number} opened in ${event.payload.repository.name}: ${event.payload.issue.title}`,
+  );
+  return await handleEvent(event, new TowtruckDatabase());
+};
+
+/**
+ * Handles the `"issues.closed"` webhook event.
+ * @param {Event<"issues.closed">} event
+ */
+export const onIssueClosed = async (event) => {
+  console.log(
+    `Issue #${event.payload.issue.number} closed in ${event.payload.repository.name}: ${event.payload.issue.title}`,
+  );
+  return await handleEvent(event, new TowtruckDatabase());
+};

--- a/webhooks/issues.test.js
+++ b/webhooks/issues.test.js
@@ -1,0 +1,75 @@
+import { describe, it } from "node:test";
+import expect from "node:assert";
+import { handleEvent } from "./issues.js";
+
+const db = {
+  saveToRepository: () => {},
+};
+
+const octokit = {
+  request: async () => {
+    return Promise.resolve({});
+  },
+};
+
+describe("handleEvent", () => {
+  it("should update the open issue information in the database for the repository", async (t) => {
+    const responses = {
+      "https://some.api/issues": {
+        data: [
+          {
+            user: {
+              login: "foo",
+            },
+            created_at: "2024-01-01T12:34:56.789Z",
+            state: "open",
+          },
+          {
+            user: {
+              login: "bar",
+            },
+            created_at: "2024-10-10T11:22:33.444Z",
+            state: "open",
+          },
+        ],
+      },
+    };
+
+    t.mock.method(octokit, "request", async (url) =>
+      Promise.resolve(responses[url]),
+    );
+    t.mock.method(db, "saveToRepository");
+
+    const payload = {
+      repository: {
+        name: "repo",
+        owner: {
+          login: "dxw",
+        },
+        issues_url: "https://some.api/issues",
+      },
+    };
+
+    const event = {
+      payload,
+      octokit,
+    };
+
+    const expected = {
+      oldestOpenIssueOpenedAt: new Date("2024-01-01T12:34:56.789Z"),
+      mostRecentIssueOpenedAt: new Date("2024-10-10T11:22:33.444Z"),
+    };
+
+    await handleEvent(event, db);
+
+    expect.strictEqual(octokit.request.mock.callCount(), 1);
+
+    expect.strictEqual(db.saveToRepository.mock.callCount(), 1);
+
+    expect.deepStrictEqual(db.saveToRepository.mock.calls[0].arguments, [
+      payload.repository.name,
+      "issues",
+      expected,
+    ]);
+  });
+});

--- a/webhooks/pullRequests.js
+++ b/webhooks/pullRequests.js
@@ -1,0 +1,42 @@
+import { TowtruckDatabase } from "../db/index.js";
+import { getOpenPRsForRepo } from "../utils/githubApi/fetchOpenPrs.js";
+
+/**
+ * @typedef {import("./index.js").Event<T>} Event<T>
+ * @template {string} T
+ */
+
+/**
+ * @param {Event<"pull_request">} event
+ * @param {TowtruckDatabase} db
+ */
+export const handleEvent = async ({ payload, octokit }, db) => {
+  const prInfo = await getOpenPRsForRepo({
+    octokit,
+    repository: payload.repository,
+  });
+
+  db.saveToRepository(payload.repository.name, "pullRequests", prInfo);
+};
+
+/**
+ * Handles the `"pull_request.opened"` webhook event.
+ * @param {Event<"pull_request.opened">} event
+ */
+export const onPullRequestOpened = async (event) => {
+  console.log(
+    `New PR #${event.payload.number} opened in ${event.payload.repository.name}: ${event.payload.pull_request.title}`,
+  );
+  return await handleEvent(event, new TowtruckDatabase());
+};
+
+/**
+ * Handles the `"pull_request.closed"` webhook event.
+ * @param {Event<"pull_request.closed">} event
+ */
+export const onPullRequestClosed = async (event) => {
+  console.log(
+    `PR #${event.payload.number} closed in ${event.payload.repository.name}: ${event.payload.pull_request.title}`,
+  );
+  return await handleEvent(event, new TowtruckDatabase());
+};

--- a/webhooks/pullRequests.test.js
+++ b/webhooks/pullRequests.test.js
@@ -1,0 +1,77 @@
+import { describe, it } from "node:test";
+import expect from "node:assert";
+import { handleEvent } from "./pullRequests.js";
+
+const db = {
+  saveToRepository: () => {},
+};
+
+const octokit = {
+  request: async () => {
+    return Promise.resolve({});
+  },
+};
+
+describe("handleEvent", () => {
+  it("should update the open pull request information in the database for the repository", async (t) => {
+    const responses = {
+      "https://some.api/pulls": {
+        data: [
+          {
+            user: {
+              login: "renovate[bot]",
+            },
+            created_at: "2024-10-10T11:22:33.444Z",
+            state: "open",
+          },
+          {
+            user: {
+              login: "foo",
+            },
+            created_at: "2024-01-01T12:34:56.789Z",
+            state: "open",
+          },
+        ],
+      },
+    };
+
+    t.mock.method(octokit, "request", async (url) =>
+      Promise.resolve(responses[url]),
+    );
+    t.mock.method(db, "saveToRepository");
+
+    const payload = {
+      repository: {
+        name: "repo",
+        owner: {
+          login: "dxw",
+        },
+        pulls_url: "https://some.api/pulls",
+      },
+    };
+
+    const event = {
+      payload,
+      octokit,
+    };
+
+    const expected = {
+      openPrCount: 2,
+      openBotPrCount: 1,
+      oldestOpenPrOpenedAt: new Date("2024-01-01T12:34:56.789Z"),
+      mostRecentPrOpenedAt: new Date("2024-10-10T11:22:33.444Z"),
+    };
+
+    await handleEvent(event, db);
+
+    expect.strictEqual(octokit.request.mock.callCount(), 1);
+
+    expect.strictEqual(db.saveToRepository.mock.callCount(), 1);
+
+    expect.deepStrictEqual(db.saveToRepository.mock.calls[0].arguments, [
+      payload.repository.name,
+      "pullRequests",
+      expected,
+    ]);
+  });
+});

--- a/webhooks/repository.js
+++ b/webhooks/repository.js
@@ -1,0 +1,30 @@
+import { TowtruckDatabase } from "../db/index.js";
+import { mapRepoFromApiForStorage } from "../utils/index.js";
+
+/**
+ * @typedef {import("./index.js").Event<T>} Event<T>
+ * @template {string} T
+ */
+
+/**
+ * @param {Event<"repository">} event
+ * @param {TowtruckDatabase} db
+ */
+export const handleEvent = async ({ payload }, db) => {
+  if (payload.repository.archived) return;
+
+  let repo = mapRepoFromApiForStorage(payload.repository);
+
+  db.saveToRepository(payload.repository.name, "main", repo);
+};
+
+/**
+ * Handles the `"repository"` webhook event.
+ * @param {Event<"repository">} event
+ */
+export const onRepository = async (event) => {
+  console.log(
+    `${event.payload.repository.name} updated: ${event.payload.action}`,
+  );
+  handleEvent(event, new TowtruckDatabase());
+};

--- a/webhooks/repository.test.js
+++ b/webhooks/repository.test.js
@@ -1,0 +1,66 @@
+import { describe, it } from "node:test";
+import expect from "node:assert";
+import { handleEvent } from "./repository.js";
+
+const db = {
+  saveToRepository: () => {},
+};
+
+const octokit = {
+  request: async () => {
+    return Promise.resolve({});
+  },
+};
+
+describe("handleEvent", () => {
+  it("should update the core information in the database for the repository", async (t) => {
+    t.mock.method(db, "saveToRepository");
+
+    const payload = {
+      repository: {
+        name: "repo",
+        description: "Some repo",
+        owner: {
+          login: "dxw",
+        },
+        url: "https://some.api/dxw/repo",
+        html_url: "https://some.site/dxw/repo",
+        issues_url: "https://some.api/issues",
+        pulls_url: "https://some.api/pulls",
+        updated_at: "2024-01-01T12:34:56.789Z",
+        language: "Ruby",
+        topics: ["foo", "bar"],
+        open_issues: 4,
+      },
+    };
+
+    const event = {
+      payload,
+      octokit,
+    };
+
+    const expected = {
+      name: "repo",
+      owner: "dxw",
+      description: "Some repo",
+      htmlUrl: "https://some.site/dxw/repo",
+      apiUrl: "https://some.api/dxw/repo",
+      pullsUrl: "https://some.api/pulls",
+      issuesUrl: "https://some.api/issues",
+      updatedAt: "2024-01-01T12:34:56.789Z",
+      language: "Ruby",
+      topics: ["foo", "bar"],
+      openIssues: 4,
+    };
+
+    await handleEvent(event, db);
+
+    expect.strictEqual(db.saveToRepository.mock.callCount(), 1);
+
+    expect.deepStrictEqual(db.saveToRepository.mock.calls[0].arguments, [
+      payload.repository.name,
+      "main",
+      expected,
+    ]);
+  });
+});


### PR DESCRIPTION
This PR allows Towtruck to listen for several types of events on the `POST /api/github/webhooks` endpoint. This can be used to incrementally update the database and spreading out the requests it makes to the GitHub API, rather than issuing a large number of requests in a short window of time as it does when seeding. 

The events it listens for are:

- `pull_request.opened` and `pull_request.closed` to update the list of open pull requests
- `issues.opened` and `issues.closed` to update the list of open issues
- `push` and `issues.edited` to update the list of dependencies
- `dependabot_alert` to update the list of vulnerabilities
- `repository` to update basic information about repositories

**NB**: this pull request depends on #63, which should be merged first.