### PR TITLE
Fix 'Lint & Test' and 'Playwright Tests' GitHub Actions workflows

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -10,9 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Read .nvmrc
+        run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
+        id: nvm
+      - name: Use Node.js ${{ steps.nvm.outputs.NODE_VERSION }}
+        uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
       - name: Install dependencies
         run: script/setup
       - name: Install Playwright Browsers

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
       - name: Install dependencies
-        run: script/setup
+        run: script/setup --ci
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
       - name: Run Playwright tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
       - name: Install dependencies
         run: |
-          ./script/setup
+          ./script/setup --ci
       - name: Run lint & test
         run: |
           ./script/test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,15 +12,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Read .nvmrc
-        run: echo "{NODE_VERSION}={$(cat .nvmrc)}" >> $GITHUB_OUTPUT
-        id: nvm
-      - name: Use Node.js ${{ steps.nvm.outputs.NODE_VERSION }}
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Read .nvmrc
+        run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
+        id: nvm
+      - name: Use Node.js ${{ steps.nvm.outputs.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
       - name: Install dependencies
         run: |
           ./script/setup

--- a/script/setup
+++ b/script/setup
@@ -17,5 +17,8 @@ fi
 
 rm -rf node_modules
 
-script/bootstrap
-
+if [ "$1" = "--ci" ]; then
+  npm install
+else
+  script/bootstrap
+fi


### PR DESCRIPTION
These workflows have suddenly stopped working with no obvious code change as the cause.

It turns out that there are two issues with the workflows, which this PR fixes:
- The `NODE_VERSION` variable was not being correctly set, so the `setup-node` action was defaulting to the latest LTS version (20.17.0).
- `nvm` is no longer available, so the `script/bootstrap` script fails.