### PR TITLE
Create `/data` folder in `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ ARG WEBHOOK_SECRET
 
 COPY . .
 
+RUN mkdir -p /data
+
 RUN touch .env \
   && echo "APP_ID=$APP_ID" >> .env \
   && echo "PRIVATE_KEY=$PRIVATE_KEY" >> .env \


### PR DESCRIPTION
Currently Towtruck does not successfully deploy as the seed scripts expect the `/data` folder to exist in order to create a SQLite database. By creating the folder in the Docker image itself, Towtruck will always have this folder available and this should allow deployments once again.