### PR TITLE
Use correct data folder path in `Dockerfile`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.env
+data
+node_modules
+playwright-report
+test-results
+*.pem

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:22.9.0-slim
 
 WORKDIR /towtruck
-VOLUME /data
+VOLUME data
 
 ARG APP_ID
 ARG PRIVATE_KEY
@@ -11,7 +11,7 @@ ARG WEBHOOK_SECRET
 
 COPY . .
 
-RUN mkdir -p /data
+RUN mkdir -p data
 
 RUN touch .env \
   && echo "APP_ID=$APP_ID" >> .env \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,3 +3,10 @@ services:
     build: .
     ports:
       - "3000:3000"
+    environment:
+      APP_ID: $APP_ID
+      PRIVATE_KEY: $PRIVATE_KEY
+      CLIENT_ID: $CLIENT_ID
+      CLIENT_SECRET: $CLIENT_SECRET
+      WEBHOOK_SECRET: $WEBHOOK_SECRET
+      REDIRECT_URL_BASE: $REDIRECT_URL_BASE


### PR DESCRIPTION
A previous attempt at a fix for failing Heroku deploys (#77) used the wrong path for the `data` volume - this has been corrected.

Additionally, some improvements have been made to make a locally built Docker image more similar to ones built by Heroku:
- A `.dockerignore` file has been introduced to ignore machine-specific files
- The `docker-compose.yml` now has environment variables included in its configuration so that `docker compose up` injects the correct values into the `.env` file inside the container