### PR TITLE
Configure GitHub OAuth setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ PRIVATE_KEY= # Use `script/encode-key <path-to-pem-file>` to encode the private 
 CLIENT_ID=SomeClientId123
 CLIENT_SECRET=secret
 WEBHOOK_SECRET=secret
+REDIRECT_URL_BASE=http://localhost:3000

--- a/octokitApp.js
+++ b/octokitApp.js
@@ -5,8 +5,10 @@ const PRIVATE_KEY = process.env.PRIVATE_KEY;
 const CLIENT_ID = process.env.CLIENT_ID;
 const CLIENT_SECRET = process.env.CLIENT_SECRET;
 const WEBHOOK_SECRET = process.env.WEBHOOK_SECRET;
+const REDIRECT_URL_BASE = process.env.REDIRECT_URL_BASE;
 
 const privateKey = Buffer.from(PRIVATE_KEY, 'base64').toString('ascii');
+const redirectUrl = `${REDIRECT_URL_BASE}/api/github/oauth/callback`;
 
 const app = new App({
   appId: APP_ID,
@@ -14,6 +16,8 @@ const app = new App({
   oauth: {
     clientId: CLIENT_ID,
     clientSecret: CLIENT_SECRET,
+    redirectUrl,
+    clientType: "github-app"
   },
   webhooks: {
     secret: WEBHOOK_SECRET,


### PR DESCRIPTION
This defines the `REDIRECT_URL_BASE` environment variable which can be used to configure which callback URL Towtruck provides when using the OAuth authentication flow.

Octokit already provides as part of its middleware the ability to authenticate as a GitHub user, so Towtruck just needs to be able to hook into this process.