### PR TITLE
Scope repositories by organisation in the database

### DIFF
--- a/utils/githubApi/fetchAllRepos.js
+++ b/utils/githubApi/fetchAllRepos.js
@@ -66,8 +66,11 @@ export const saveAllRepos = async (allRepos, db) => {
     console.info("Saving all repos...");
     const saveAllRepos = db.transaction((repos) => {
       repos.forEach((repo) => {
-        const name = repo.repo.name;
+        const repoName = repo.repo.name;
         const owner = repo.repo.owner;
+
+        const name = `${owner}/${repoName}`;
+        
         db.saveToRepository(name, "main", repo.repo);
         db.saveToRepository(name, "owner", owner);
         db.saveToRepository(name, "dependencies", repo.dependencies);

--- a/utils/githubApi/fetchAllRepos.test.js
+++ b/utils/githubApi/fetchAllRepos.test.js
@@ -324,63 +324,63 @@ describe("saveAllRepos", () => {
     expect.strictEqual(db.saveToRepository.mock.callCount(), 12);
 
     expect.deepStrictEqual(db.saveToRepository.mock.calls[0].arguments, [
-      repo1.repo.name,
+      "dxw/repo1",
       "main",
       repo1.repo,
     ]);
     expect.deepStrictEqual(db.saveToRepository.mock.calls[1].arguments, [
-      repo1.repo.name,
+      "dxw/repo1",
       "owner",
       repo1.repo.owner,
     ]);
     expect.deepStrictEqual(db.saveToRepository.mock.calls[2].arguments, [
-      repo1.repo.name,
+      "dxw/repo1",
       "dependencies",
       repo1.dependencies,
     ]);
     expect.deepStrictEqual(db.saveToRepository.mock.calls[3].arguments, [
-      repo1.repo.name,
+      "dxw/repo1",
       "pullRequests",
       repo1.prInfo,
     ]);
     expect.deepStrictEqual(db.saveToRepository.mock.calls[4].arguments, [
-      repo1.repo.name,
+      "dxw/repo1",
       "issues",
       repo1.issueInfo,
     ]);
     expect.deepStrictEqual(db.saveToRepository.mock.calls[5].arguments, [
-      repo1.repo.name,
+      "dxw/repo1",
       "dependabotAlerts",
       repo1.alerts,
     ]);
 
     expect.deepStrictEqual(db.saveToRepository.mock.calls[6].arguments, [
-      repo2.repo.name,
+      "dxw/repo2",
       "main",
       repo2.repo,
     ]);
     expect.deepStrictEqual(db.saveToRepository.mock.calls[7].arguments, [
-      repo2.repo.name,
+      "dxw/repo2",
       "owner",
       repo2.repo.owner,
     ]);
     expect.deepStrictEqual(db.saveToRepository.mock.calls[8].arguments, [
-      repo2.repo.name,
+      "dxw/repo2",
       "dependencies",
       repo2.dependencies,
     ]);
     expect.deepStrictEqual(db.saveToRepository.mock.calls[9].arguments, [
-      repo2.repo.name,
+      "dxw/repo2",
       "pullRequests",
       repo2.prInfo,
     ]);
     expect.deepStrictEqual(db.saveToRepository.mock.calls[10].arguments, [
-      repo2.repo.name,
+      "dxw/repo2",
       "issues",
       repo2.issueInfo,
     ]);
     expect.deepStrictEqual(db.saveToRepository.mock.calls[11].arguments, [
-      repo2.repo.name,
+      "dxw/repo2",
       "dependabotAlerts",
       repo2.alerts,
     ]);


### PR DESCRIPTION
This now saves repository-scoped data with the `name` being of the format `org/reponame`. This allows for a method like `getAllRepositoriesForOrg`, which provides two benefits:
1. Towtruck can provide per-organisation dashboards.
2. Towtruck can restrict access to organisations for which the logged in user should not have access.