### PR TITLE
Introduce a Config object to hold common app configuration

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,0 +1,16 @@
+export const Config = {
+    gitHub: {
+        appId: process.env.APP_ID,
+        clientId: process.env.CLIENT_ID,
+        clientSecret: process.env.CLIENT_SECRET,
+        webhookSecret: process.env.WEBHOOK_SECRET,
+    },
+    env: {
+        isCi: !!process.env.CI
+    },
+    privateKey: Buffer.from(process.env.PRIVATE_KEY, 'base64').toString('ascii'),
+    port: process.env.PORT || 3000,
+    redirectUrlBase: process.env.REDIRECT_URL_BASE,
+    loginMethods: Object.assign(...(process.env.LOGIN_METHODS || "").split(',').map(k => ({ [k]: true })), {}),
+    tokenExpiry: process.env.TOKEN_EXPIRY || '24h'
+};

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ import { mapRepoFromStorageToUi } from "./utils/index.js";
 import { sortByType } from "./utils/sorting.js";
 import { TowtruckDatabase } from "./db/index.js";
 import { handleWebhooks } from "./webhooks/index.js";
+import { Config } from "./config.js";
 
 nunjucks.configure({
   autoescape: true,
@@ -39,7 +40,6 @@ httpServer.all("*path", (request, response) => {
   return response.status(404).render("404", { url: request.path });
 });
 
-const PORT = process.env.PORT || 3000;
-httpServer.listen(PORT, () => {
-  console.info(`Server is running on port ${PORT}`);
+httpServer.listen(Config.port, () => {
+  console.info(`Server is running on port ${Config.port}`);
 });

--- a/octokitApp.js
+++ b/octokitApp.js
@@ -1,26 +1,17 @@
 import { App } from "@octokit/app";
-
-const APP_ID = process.env.APP_ID;
-const PRIVATE_KEY = process.env.PRIVATE_KEY;
-const CLIENT_ID = process.env.CLIENT_ID;
-const CLIENT_SECRET = process.env.CLIENT_SECRET;
-const WEBHOOK_SECRET = process.env.WEBHOOK_SECRET;
-const REDIRECT_URL_BASE = process.env.REDIRECT_URL_BASE;
-
-const privateKey = Buffer.from(PRIVATE_KEY, 'base64').toString('ascii');
-const redirectUrl = `${REDIRECT_URL_BASE}/api/github/oauth/callback`;
+import { Config } from "./config.js";
 
 const app = new App({
-  appId: APP_ID,
-  privateKey,
+  appId: Config.gitHub.appId,
+  privateKey: Config.privateKey,
   oauth: {
-    clientId: CLIENT_ID,
-    clientSecret: CLIENT_SECRET,
-    redirectUrl,
+    clientId: Config.gitHub.clientId,
+    clientSecret: Config.gitHub.clientSecret,
+    redirectUrl: `${Config.redirectUrlBase}/login/github`,
     clientType: "github-app"
   },
   webhooks: {
-    secret: WEBHOOK_SECRET,
+    secret: Config.gitHub.webhookSecret,
   },
 });
 


### PR DESCRIPTION
Some properties are required in multiple places (such as the private key, which is used to sign JWTs and by Octokit to authenticate to GitHub), so rather than repeating `process.env` and associated parsing logic throughout the code, this object does it all in one place.