### PR TITLE
Make links relative in sortable table header Nunjucks macro

### DIFF
--- a/views/_macros.njk
+++ b/views/_macros.njk
@@ -14,22 +14,22 @@
     
     
 {% set sortingOnThisParam = id === sortBy %}
-{% set linkParams = "?sortBy=" + id + "&sortDirection=asc" %}
+{% set queryParams = "?sortBy=" + id + "&sortDirection=asc" %}
 {%set ariaSort = "none"%}
 
 {%if sortingOnThisParam and sortDirection === "asc"%}
-    {% set linkParams = "?sortBy=" + id + "&sortDirection=desc" %}
+    {% set queryParams = "?sortBy=" + id + "&sortDirection=desc" %}
     {%set ariaSort = "ascending"%}
 {%endif%}
 
 {%if sortingOnThisParam and sortDirection === "desc"%}
-    {% set linkParams = "?sortBy=" + id + "&sortDirection=asc" %}
+    {% set queryParams = "?sortBy=" + id + "&sortDirection=asc" %}
     {%set ariaSort = "descending"%}
 {%endif%}
 
 
 
-<th class="py-2 pl-2" scope="col" aria-sort="{{ariaSort}}"><a href="/{{linkParams}}"> {{name}}
+<th class="py-2 pl-2" scope="col" aria-sort="{{ariaSort}}"><a href="{{queryParams}}"> {{name}}
 
     <span class="text-xs ml-1 whitespace-nowrap">
         {% if sortDirection === "asc" and sortingOnThisParam %}


### PR DESCRIPTION
The `sortableTableHeader` macro will generate links that use query parameters to control the sorting of the dashboard. However, as the table header links are of the form
`/?sortBy=<sort>&sortDirection=<direction>`, they will only work correctly when used on the root path. To make them usable anywhere, just the query part of the URL can be used as the `href`, which will link to the current page with the updated query parameters.