### PR TITLE
Introduce a 404 page

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,10 @@ httpServer.get("/", (request, response) => {
   });
 });
 
+httpServer.all("*path", (request, response) => {
+  return response.status(404).render("404", { url: request.path });
+});
+
 const PORT = process.env.PORT || 3000;
 httpServer.listen(PORT, () => {
   console.info(`Server is running on port ${PORT}`);

--- a/views/404.njk
+++ b/views/404.njk
@@ -1,0 +1,11 @@
+{% extends "./_base.njk" %}
+
+{% block content %}
+<div class="bg-stone-50 dark:bg-stone-700 rounded-lg border-b-4 border-stone-200 dark:border-stone-900 p-12 space-y-4 m-auto mt-32">
+  <div class="text-center">The requested page <strong>{{ url }}</strong> could not be found.</div>
+  <hr />
+  <div class="text-center">
+    <a class="inline-block text-base text-sky-600 dark:text-sky-500 hover:underline" href="/">Return to the home page.</a>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
When a user tries to navigate to a page that doesn't exist, a 404 response should be presented. Most server frameworks handle this automatically, but the default page presented won't look like part of the application.

To make the 404 page look like the rest of the application, a new view has been introduced that uses the base template. A catch-all route has been defined that will render this view with the path that the user attempted to navigate to, an explanatory message, and a link back to the home page.