### PR TITLE
Show repos in order

### DIFF
--- a/e2es/towtruck.spec.js
+++ b/e2es/towtruck.spec.js
@@ -5,6 +5,8 @@ test("has dependency info", async ({ page, baseURL }) => {
 
   await expect(page).toHaveTitle(/Towtruck/);
 
+  await assertFirstDependencyRow("govuk-blogs", page);
+
   page.getByText("There are 3 repositories that Towtruck is tracking for dxw.");
 
   const tableHeadings = [

--- a/index.js
+++ b/index.js
@@ -21,7 +21,8 @@ httpServer.get("/", (request, response) => {
   const reposForUi = mapRepoFromStorageToUi(persistedRepoData, persistedLifetimeData);
   const filteredReposForUi = filterReposWithOpenPrs(reposForUi);
 
-  const { sortDirection, sortBy } = request.query;
+  const sortBy = request.query.sortBy || "openBotPrCount";
+  const sortDirection = request.query.sortDirection || "desc";
 
   const template = nunjucks.render("index.njk", {
     sortBy,

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import express from "express";
 import nunjucks from "nunjucks";
-import { mapRepoFromStorageToUi } from "./utils/index.js";
+import { mapRepoFromStorageToUi, filterReposWithOpenPrs } from "./utils/index.js";
 import { sortByType } from "./utils/sorting.js";
 import { TowtruckDatabase } from "./db/index.js";
 import { handleWebhooks } from "./webhooks/index.js";
@@ -19,14 +19,15 @@ httpServer.get("/", (request, response) => {
   const persistedLifetimeData = db.getAllDependencies();
 
   const reposForUi = mapRepoFromStorageToUi(persistedRepoData, persistedLifetimeData);
+  const filteredReposForUi = filterReposWithOpenPrs(reposForUi);
 
   const { sortDirection, sortBy } = request.query;
 
   const template = nunjucks.render("index.njk", {
     sortBy,
     sortDirection,
-    ...reposForUi,
-    repos: sortByType(reposForUi.repos, sortDirection, sortBy),
+    ...filteredReposForUi,
+    repos: sortByType(filteredReposForUi.repos, sortDirection, sortBy),
   });
 
   return response.end(template);

--- a/utils/index.js
+++ b/utils/index.js
@@ -175,6 +175,21 @@ export const mapRepoFromStorageToUi = (persistedData, persistedLifetimes) => {
 };
 
 /**
+ * Filters UI repo data to repositories that currently have open pull requests.
+ * @param {RepoData} repoData
+ * @returns {RepoData}
+ */
+export const filterReposWithOpenPrs = (repoData) => {
+  const repos = repoData.repos.filter((repo) => repo.openPrCount > 0);
+
+  return {
+    ...repoData,
+    repos,
+    totalRepos: repos.length,
+  };
+};
+
+/**
  * @typedef {Object} ApiRepo
  * @property {string} name - The name of the repo Eg "dalmation".
  * @property {string} description - A brief description of the repo.

--- a/utils/index.test.js
+++ b/utils/index.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import expect from "node:assert";
-import { mapRepoFromStorageToUi, mapRepoFromApiForStorage, hashToTailwindColor } from "./index.js";
+import { mapRepoFromStorageToUi, mapRepoFromApiForStorage, hashToTailwindColor, filterReposWithOpenPrs } from "./index.js";
 import { formatDistanceToNow } from "date-fns";
 
 describe("mapRepoFromStorageToUi", () => {
@@ -470,4 +470,48 @@ describe("hashToTailwindColor", () => {
       expect.strictEqual(actual, expected);
     }
   });
-})
+});
+
+describe("filterReposWithOpenPrs", () => {
+  it("keeps only repos with at least one open PR and updates totalRepos", () => {
+    const repoData = {
+      org: "dxw",
+      totalRepos: 3,
+      repos: [
+        { name: "repo-with-prs", openPrCount: 2 },
+        { name: "repo-without-prs", openPrCount: 0 },
+        { name: "repo-with-more-prs", openPrCount: 5 },
+      ],
+    };
+
+    const actual = filterReposWithOpenPrs(repoData);
+
+    expect.deepEqual(actual, {
+      org: "dxw",
+      totalRepos: 2,
+      repos: [
+        { name: "repo-with-prs", openPrCount: 2 },
+        { name: "repo-with-more-prs", openPrCount: 5 },
+      ],
+    });
+  });
+
+  it("returns an empty list when no repos have open PRs", () => {
+    const repoData = {
+      org: "dxw",
+      totalRepos: 2,
+      repos: [
+        { name: "repo-1", openPrCount: 0 },
+        { name: "repo-2", openPrCount: 0 },
+      ],
+    };
+
+    const actual = filterReposWithOpenPrs(repoData);
+
+    expect.deepEqual(actual, {
+      org: "dxw",
+      totalRepos: 0,
+      repos: [],
+    });
+  });
+});

--- a/utils/sorting.js
+++ b/utils/sorting.js
@@ -58,32 +58,38 @@ export const sortByISO8601Timestamp = (repos, sortDirection, key) => {
  * @returns {UiRepo[]} The sorted array of repository objects.
  */
 export const sortByType = (repos, sortDirection, sortBy) => {
+  if (!sortBy) {
+    return sortByNumericValue(repos, "desc", "openBotPrCount");
+  }
+
+  const safeSortDirection = sortDirection || "desc";
+
   switch (sortBy) {
     case "openPrCount":
-      return sortByNumericValue(repos, sortDirection, "openPrCount");
+      return sortByNumericValue(repos, safeSortDirection, "openPrCount");
 
     case "openBotPrCount":
-      return sortByNumericValue(repos, sortDirection, "openBotPrCount");
+      return sortByNumericValue(repos, safeSortDirection, "openBotPrCount");
 
     case "openIssues":
-      return sortByNumericValue(repos, sortDirection, "openIssues");
+      return sortByNumericValue(repos, safeSortDirection, "openIssues");
 
     case "updatedAt":
-      return sortByISO8601Timestamp(repos, sortDirection, "updatedAtISO8601");
+      return sortByISO8601Timestamp(repos, safeSortDirection, "updatedAtISO8601");
 
     case "mostRecentPrOpenedAt":
-      return sortByISO8601Timestamp(repos, sortDirection, "mostRecentPrOpenedAtISO8601");
+      return sortByISO8601Timestamp(repos, safeSortDirection, "mostRecentPrOpenedAtISO8601");
 
     case "oldestOpenPrOpenedAt":
-      return sortByISO8601Timestamp(repos, sortDirection, "oldestOpenPrOpenedAtISO8601");
+      return sortByISO8601Timestamp(repos, safeSortDirection, "oldestOpenPrOpenedAtISO8601");
 
     case "mostRecentIssueOpenedAt":
-      return sortByISO8601Timestamp(repos, sortDirection, "mostRecentIssueOpenedAtISO8601");
+      return sortByISO8601Timestamp(repos, safeSortDirection, "mostRecentIssueOpenedAtISO8601");
 
     case "oldestOpenIssueOpenedAt":
-      return sortByISO8601Timestamp(repos, sortDirection, "oldestOpenIssueOpenedAtISO8601");
+      return sortByISO8601Timestamp(repos, safeSortDirection, "oldestOpenIssueOpenedAtISO8601");
 
     default:
-      return repos;
+      return sortByNumericValue(repos, "desc", "openBotPrCount");
   }
 };

--- a/utils/sorting.test.js
+++ b/utils/sorting.test.js
@@ -117,14 +117,18 @@ describe("sortByType", () => {
     );
   });
 
-  it("returns the original array if the sortBy parameter is passed", () => {
+  it("defaults to sorting by openBotPrCount in descending order when sortBy is not provided", () => {
     const reposToSort = [
-      { name: "Repo 1", openIssues: 5 },
-      { name: "Repo 2", openIssues: 3 },
-      { name: "Repo 3", openIssues: 7 },
+      { name: "Repo 1", openBotPrCount: 5 },
+      { name: "Repo 2", openBotPrCount: 3 },
+      { name: "Repo 3", openBotPrCount: 7 },
     ];
 
-    expect.deepEqual(sortByType(reposToSort, "asc", null), reposToSort);
+    expect.deepEqual(sortByType(reposToSort, "asc", null), [
+      { name: "Repo 3", openBotPrCount: 7 },
+      { name: "Repo 1", openBotPrCount: 5 },
+      { name: "Repo 2", openBotPrCount: 3 },
+    ]);
   });
 
   it('sorts the repos by the date they were last updated if "updatedAt" is provided', () => {
@@ -190,5 +194,34 @@ describe("sortByType", () => {
       sortByType(reposToSort, "asc", "oldestOpenIssueOpenedAt"),
       sortByISO8601Timestamp(reposToSort, "asc", "oldestOpenIssueOpenedAtISO8601")
     );
+  });
+
+  it("sorts by openPrCount in descending order when given 'desc'", () => {
+    const reposToSort = [
+      { name: "Repo 1", openPrCount: 2 },
+      { name: "Repo 2", openPrCount: 7 },
+      { name: "Repo 3", openPrCount: 5 },
+    ];
+
+    expect.deepEqual(sortByType(reposToSort, "desc", "openPrCount"), [
+      { name: "Repo 2", openPrCount: 7 },
+      { name: "Repo 3", openPrCount: 5 },
+      { name: "Repo 1", openPrCount: 2 },
+    ]);
+  });
+
+
+  it("defaults to sorting by openBotPrCount in descending order when sortBy is unknown", () => {
+    const reposToSort = [
+      { name: "Repo 1", openBotPrCount: 2 },
+      { name: "Repo 2", openBotPrCount: 7 },
+      { name: "Repo 3", openBotPrCount: 5 },
+    ];
+
+    expect.deepEqual(sortByType(reposToSort, "asc", "unknown"), [
+      { name: "Repo 2", openBotPrCount: 7 },
+      { name: "Repo 3", openBotPrCount: 5 },
+      { name: "Repo 1", openBotPrCount: 2 },
+    ]);
   });
 });


### PR DESCRIPTION
This PR updates towtruck to show repos in descending order of open bot PRs as default (you can still use the toggles to change the display).

It now also only shows repos with open PRs

made in collaboration with copilot