### PR TITLE
Add GovPress mode to filter repos tagged 'govpress'

### DIFF
--- a/e2es/govpressMode.spec.js
+++ b/e2es/govpressMode.spec.js
@@ -1,0 +1,32 @@
+import { test, expect } from "@playwright/test";
+
+test("GovPress mode shows only repos marked govpress", async ({ page, baseURL }) => {
+  await page.goto(baseURL);
+  await page.getByRole("link", { name: "dxw" }).click();
+
+  // Navigate to GovPress mode
+  await page.getByRole("link", { name: "GovPress mode" }).click();
+
+  // Should display the GovPress info banner
+  await expect(page.getByText("This dashboard shows only repos marked GovPress.")).toBeVisible();
+
+  // Should show an "Exit GovPress mode" button
+  await expect(page.getByRole("link", { name: "Exit GovPress mode" })).toBeVisible();
+
+  // Should show repos that are tagged "govpress"
+  await expect(page.getByRole("link", { name: "govuk-blogs" })).toBeVisible();
+});
+
+test("GovPress mode can be exited back to normal view", async ({ page, baseURL }) => {
+  await page.goto(`${baseURL}/dxw/govpress`);
+
+  await page.getByRole("link", { name: "Exit GovPress mode" }).click();
+
+  // Should be back on the normal org page
+  await expect(page.getByText("Towtruck is tracking for dxw")).toBeVisible();
+
+  // Should show both D+ mode and GovPress mode buttons
+  await expect(page.getByRole("link", { name: "D+ mode" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "GovPress mode" })).toBeVisible();
+});
+

--- a/index.js
+++ b/index.js
@@ -132,7 +132,75 @@ httpServer.get("/:org/d-plus", requireAuth, (request, response) => {
     savedConfigurations: [],
     activeConfigId: null,
     dPlusMode: true,
+    govpressMode: false,
     dPlusBaseUrl: `/${org}/d-plus`,
+    govpressBaseUrl: `/${org}/govpress`,
+  });
+
+  return response.end(template);
+});
+
+httpServer.get("/:org/govpress", requireAuth, (request, response) => {
+  const { org } = request.params;
+  const db = new TowtruckDatabase();
+  const persistedRepoData = db.getAllRepositoriesForOrg(org);
+  const persistedLifetimeData = db.getAllDependencies();
+
+  // Resolve date format: query param takes precedence.
+  // Only persist DD/MM/YY in the cookie; MM/DD/YYYY must be explicitly passed each navigation.
+  const dateFormat = normalizeDateStyle(request.query.dateFormat ?? (request.cookies?.dateFormat === "DD/MM/YY" ? "DD/MM/YY" : undefined));
+  if (request.cookies?.dateFormat !== dateFormat) {
+    response.cookie("dateFormat", dateFormat, { httpOnly: false, sameSite: "lax" });
+  }
+
+  const reposForUi = mapRepoFromStorageToUi(persistedRepoData, persistedLifetimeData, dateFormat);
+
+  const { sortDirection, sortBy, page: pageParam, alertFilter } = request.query;
+
+  const govpressOnly = filterByTags(reposForUi.repos, ["govpress"]);
+  const filteredByAlerts = filterByAlerts(govpressOnly, alertFilter);
+  const sortedRepos = sortByType(filteredByAlerts, sortDirection, sortBy);
+  const paginationData = calculatePagination(sortedRepos, pageParam);
+
+  const totalVulnerabilities = govpressOnly.reduce((sum, repo) => sum + (repo.totalOpenAlerts ?? 0), 0);
+  const totalCriticalVulnerabilities = govpressOnly.reduce((sum, repo) => sum + (repo.criticalSeverityAlerts ?? 0), 0);
+
+  const buildTopicFilterUrl = () => {
+    const params = new URLSearchParams();
+    if (sortBy) params.set("sortBy", sortBy);
+    if (sortDirection) params.set("sortDirection", sortDirection);
+    if (alertFilter) params.set("alertFilter", alertFilter);
+
+    const queryString = params.toString();
+    return queryString ? `/${org}/govpress?${queryString}` : `/${org}/govpress`;
+  };
+
+  const template = nunjucks.render("index.njk", {
+    sortBy,
+    sortDirection,
+    tag: "",
+    selectedTags: [],
+    buildTopicFilterUrl,
+    alertFilter,
+    dateFormat,
+    ...reposForUi,
+    totalVulnerabilities,
+    totalCriticalVulnerabilities,
+    org,
+    repos: paginationData.items,
+    totalRepos: reposForUi.totalRepos,
+    displayedRepos: filteredByAlerts.length,
+    currentPage: paginationData.currentPage,
+    totalPages: paginationData.totalPages,
+    pageNumbers: paginationData.pageNumbers,
+    hasPreviousPage: paginationData.hasPreviousPage,
+    hasNextPage: paginationData.hasNextPage,
+    savedConfigurations: [],
+    activeConfigId: null,
+    dPlusMode: false,
+    govpressMode: true,
+    dPlusBaseUrl: `/${org}/d-plus`,
+    govpressBaseUrl: `/${org}/govpress`,
   });
 
   return response.end(template);
@@ -220,7 +288,9 @@ httpServer.get("/:org", requireAuth, (request, response) => {
     savedConfigurations,
     activeConfigId,
     dPlusMode: false,
+    govpressMode: false,
     dPlusBaseUrl: `/${org}/d-plus`,
+    govpressBaseUrl: `/${org}/govpress`,
   });
 
   return response.end(template);

--- a/index.njk
+++ b/index.njk
@@ -18,7 +18,7 @@
     </script>
   </head>
   <body class="bg-slate-200 text-slate-900 dark:bg-slate-950 dark:text-slate-100">
-    {% set baseUrl = dPlusBaseUrl if dPlusMode else "/" + org %}
+    {% set baseUrl = dPlusBaseUrl if dPlusMode else (govpressBaseUrl if govpressMode else "/" + org) %}
     <header class="bg-slate-600 dark:bg-slate-900 text-white">
       <nav class="w-full flex items-center gap-4 p-6 border-b-4 border-slate-700 dark:border-slate-950">
         <a href="/" class="text-slate-300 hover:text-white transition-colors" aria-label="Back to home">
@@ -29,10 +29,18 @@
         <a href="/{{ org }}" class="inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-sm font-medium transition-colors bg-slate-500 text-white border-slate-400 hover:bg-slate-400">
           Exit D+ mode
         </a>
+        {% elif govpressMode %}
+        <a href="/{{ org }}" class="inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-sm font-medium transition-colors bg-slate-500 text-white border-slate-400 hover:bg-slate-400">
+          Exit GovPress mode
+        </a>
         {% else %}
-        <a href="/{{ org }}/d-plus" class="inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-sm font-medium transition-colors bg-blue-600 text-white border-blue-500 hover:bg-blue-500">
+        <a href="/{{ org }}/d-plus" class="inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-sm font-medium transition-colors bg-purple-600 text-white border-purple-500 hover:bg-purple-500">
           <i class="bx bx-rocket"></i>
           D+ mode
+        </a>
+        <a href="/{{ org }}/govpress" class="inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-sm font-medium transition-colors bg-orange-600 text-white border-orange-500 hover:bg-orange-500">
+          <i class="bx bx-globe"></i>
+          GovPress mode
         </a>
         {% endif %}
         <button id="theme-toggle" aria-label="Toggle dark mode"
@@ -43,9 +51,14 @@
     </header>
 
     {% if dPlusMode %}
-    <div class="bg-blue-600 dark:bg-blue-700 border-b-4 border-blue-800 dark:border-blue-900 px-6 py-4 text-white font-semibold text-base flex items-center gap-2">
+    <div class="bg-purple-600 dark:bg-purple-700 border-b-4 border-purple-800 dark:border-purple-900 px-6 py-4 text-white font-semibold text-base flex items-center gap-2">
       <i class="bx bx-info-circle text-xl"></i>
       This dashboard shows only repos not marked GovPress.
+    </div>
+    {% elif govpressMode %}
+    <div class="bg-orange-600 dark:bg-orange-700 border-b-4 border-orange-800 dark:border-orange-900 px-6 py-4 text-white font-semibold text-base flex items-center gap-2">
+      <i class="bx bx-info-circle text-xl"></i>
+      This dashboard shows only repos marked GovPress.
     </div>
     {% endif %}
 


### PR DESCRIPTION
- Add /:org/govpress route that shows only repos marked with the 'govpress' topic (mirrors D+ mode which excludes them)
- Add GovPress mode button (orange) and D+ mode button (purple) to nav
- Show info banner when in GovPress mode
- Add e2e tests for GovPress mode navigation and exit