### PR TITLE
Last update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,5 @@ towtruck.private-key.pem
 # SQLite
 *.db-wal
 *.db-shm
+doc/gmail-smtp-setup.md
+doc/slack-integration-setup.md

--- a/db/index.js
+++ b/db/index.js
@@ -168,6 +168,32 @@ export class TowtruckDatabase {
     return stmt.run(`${org}/${id}`, userEmail);
   }
 
+  saveEmailSubscription(org, userEmail, { tags, criticalAlerts }) {
+    const name = `${org}/${userEmail}`;
+    return this.#save("email-subscription", name, "preferences", {
+      org,
+      userEmail,
+      tags: tags || [],
+      criticalAlerts: !!criticalAlerts,
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  getEmailSubscription(org, userEmail) {
+    const name = `${org}/${userEmail}`;
+    return this.#get("email-subscription", name, "preferences");
+  }
+
+  deleteEmailSubscription(org, userEmail) {
+    const rawDb = this.#db;
+    const stmt = rawDb.prepare("DELETE FROM towtruck_data WHERE scope = 'email-subscription' AND name = ?;");
+    return stmt.run(`${org}/${userEmail}`);
+  }
+
+  getAllEmailSubscriptions() {
+    return this.#getAllForScope("email-subscription");
+  }
+
   transaction(fn) {
     return this.#db.transaction(fn);
   }

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ import { mapRepoFromStorageToUi, getOrgs } from "./utils/index.js";
 import { normalizeDateStyle } from "./utils/dateFormatting.js";
 import { sortByType } from "./utils/sorting.js";
 import { filterByAlerts } from "./utils/alertFiltering.js";
-import { normalizeSelectedTags, filterByTags, excludeByTag } from "./utils/tagFiltering.js";
+import { normalizeSelectedTags, filterByTags } from "./utils/tagFiltering.js";
 import { calculatePagination } from "./utils/pagination.js";
 import { TowtruckDatabase } from "./db/index.js";
 import { handleWebhooks } from "./webhooks/index.js";
@@ -91,13 +91,13 @@ httpServer.get("/:org/d-plus", requireAuth, (request, response) => {
 
   const { sortDirection, sortBy, page: pageParam, alertFilter } = request.query;
 
-  const govpressExcluded = excludeByTag(reposForUi.repos, "govpress");
-  const filteredByAlerts = filterByAlerts(govpressExcluded, alertFilter);
+  const dPlusRepos = filterByTags(reposForUi.repos, ["d-plus", "delivery-plus", "internal"]);
+  const filteredByAlerts = filterByAlerts(dPlusRepos, alertFilter);
   const sortedRepos = sortByType(filteredByAlerts, sortDirection, sortBy);
   const paginationData = calculatePagination(sortedRepos, pageParam);
 
-  const totalVulnerabilities = govpressExcluded.reduce((sum, repo) => sum + (repo.totalOpenAlerts ?? 0), 0);
-  const totalCriticalVulnerabilities = govpressExcluded.reduce((sum, repo) => sum + (repo.criticalSeverityAlerts ?? 0), 0);
+  const totalVulnerabilities = dPlusRepos.reduce((sum, repo) => sum + (repo.totalOpenAlerts ?? 0), 0);
+  const totalCriticalVulnerabilities = dPlusRepos.reduce((sum, repo) => sum + (repo.criticalSeverityAlerts ?? 0), 0);
 
   const buildTopicFilterUrl = () => {
     const params = new URLSearchParams();
@@ -133,8 +133,10 @@ httpServer.get("/:org/d-plus", requireAuth, (request, response) => {
     activeConfigId: null,
     dPlusMode: true,
     govpressMode: false,
+    opsMode: false,
     dPlusBaseUrl: `/${org}/d-plus`,
     govpressBaseUrl: `/${org}/govpress`,
+    opsBaseUrl: `/${org}/ops`,
   });
 
   return response.end(template);
@@ -199,8 +201,77 @@ httpServer.get("/:org/govpress", requireAuth, (request, response) => {
     activeConfigId: null,
     dPlusMode: false,
     govpressMode: true,
+    opsMode: false,
     dPlusBaseUrl: `/${org}/d-plus`,
     govpressBaseUrl: `/${org}/govpress`,
+    opsBaseUrl: `/${org}/ops`,
+  });
+
+  return response.end(template);
+});
+
+
+httpServer.get("/:org/ops", requireAuth, (request, response) => {
+  const { org } = request.params;
+  const db = new TowtruckDatabase();
+  const persistedRepoData = db.getAllRepositoriesForOrg(org);
+  const persistedLifetimeData = db.getAllDependencies();
+
+  const dateFormat = normalizeDateStyle(request.query.dateFormat ?? (request.cookies?.dateFormat === "DD/MM/YY" ? "DD/MM/YY" : undefined));
+  if (request.cookies?.dateFormat !== dateFormat) {
+    response.cookie("dateFormat", dateFormat, { httpOnly: false, sameSite: "lax" });
+  }
+
+  const reposForUi = mapRepoFromStorageToUi(persistedRepoData, persistedLifetimeData, dateFormat);
+
+  const { sortDirection, sortBy, page: pageParam, alertFilter } = request.query;
+
+  const opsRepos = filterByTags(reposForUi.repos, ["dalmatian", "tech-ops"]);
+  const filteredByAlerts = filterByAlerts(opsRepos, alertFilter);
+  const sortedRepos = sortByType(filteredByAlerts, sortDirection, sortBy);
+  const paginationData = calculatePagination(sortedRepos, pageParam);
+
+  const totalVulnerabilities = opsRepos.reduce((sum, repo) => sum + (repo.totalOpenAlerts ?? 0), 0);
+  const totalCriticalVulnerabilities = opsRepos.reduce((sum, repo) => sum + (repo.criticalSeverityAlerts ?? 0), 0);
+
+  const buildTopicFilterUrl = () => {
+    const params = new URLSearchParams();
+    if (sortBy) params.set("sortBy", sortBy);
+    if (sortDirection) params.set("sortDirection", sortDirection);
+    if (alertFilter) params.set("alertFilter", alertFilter);
+
+    const queryString = params.toString();
+    return queryString ? `/${org}/ops?${queryString}` : `/${org}/ops`;
+  };
+
+  const template = nunjucks.render("index.njk", {
+    sortBy,
+    sortDirection,
+    tag: "",
+    selectedTags: [],
+    buildTopicFilterUrl,
+    alertFilter,
+    dateFormat,
+    ...reposForUi,
+    totalVulnerabilities,
+    totalCriticalVulnerabilities,
+    org,
+    repos: paginationData.items,
+    totalRepos: reposForUi.totalRepos,
+    displayedRepos: filteredByAlerts.length,
+    currentPage: paginationData.currentPage,
+    totalPages: paginationData.totalPages,
+    pageNumbers: paginationData.pageNumbers,
+    hasPreviousPage: paginationData.hasPreviousPage,
+    hasNextPage: paginationData.hasNextPage,
+    savedConfigurations: [],
+    activeConfigId: null,
+    dPlusMode: false,
+    govpressMode: false,
+    opsMode: true,
+    dPlusBaseUrl: `/${org}/d-plus`,
+    govpressBaseUrl: `/${org}/govpress`,
+    opsBaseUrl: `/${org}/ops`,
   });
 
   return response.end(template);
@@ -289,11 +360,60 @@ httpServer.get("/:org", requireAuth, (request, response) => {
     activeConfigId,
     dPlusMode: false,
     govpressMode: false,
+    opsMode: false,
     dPlusBaseUrl: `/${org}/d-plus`,
     govpressBaseUrl: `/${org}/govpress`,
+    opsBaseUrl: `/${org}/ops`,
   });
 
   return response.end(template);
+});
+
+
+httpServer.get("/:org/settings", requireAuth, (request, response) => {
+  const { org } = request.params;
+  const db = new TowtruckDatabase();
+  const persistedRepoData = db.getAllRepositoriesForOrg(org);
+  const { repos } = mapRepoFromStorageToUi(persistedRepoData, {});
+
+  // Collect all unique topics across repos
+  const allTopics = [...new Set(repos.flatMap((repo) => repo.topics || []))].sort();
+
+  const subscription = db.getEmailSubscription(org, request.session.user.email) || { tags: [], criticalAlerts: false };
+
+  const template = nunjucks.render("settings.njk", {
+    org,
+    allTopics,
+    subscription,
+    email: request.session.user.email,
+    saved: request.query.saved,
+    deleted: request.query.deleted,
+  });
+
+  return response.end(template);
+});
+
+httpServer.post("/:org/settings/email-subscription", requireAuth, (request, response) => {
+  const { org } = request.params;
+  const { tags, criticalAlerts } = request.body;
+
+  const selectedTags = Array.isArray(tags) ? tags : (tags ? [tags] : []);
+
+  const db = new TowtruckDatabase();
+  db.saveEmailSubscription(org, request.session.user.email, {
+    tags: selectedTags,
+    criticalAlerts: criticalAlerts === "on",
+  });
+
+  return response.redirect(`/${org}/settings?saved=1`);
+});
+
+httpServer.post("/:org/settings/email-subscription/delete", requireAuth, (request, response) => {
+  const { org } = request.params;
+  const db = new TowtruckDatabase();
+  db.deleteEmailSubscription(org, request.session.user.email);
+
+  return response.redirect(`/${org}/settings?deleted=1`);
 });
 
 httpServer.post("/:org/saved-configurations", requireAuth, (request, response) => {

--- a/index.njk
+++ b/index.njk
@@ -18,7 +18,7 @@
     </script>
   </head>
   <body class="bg-slate-200 text-slate-900 dark:bg-slate-950 dark:text-slate-100">
-    {% set baseUrl = dPlusBaseUrl if dPlusMode else (govpressBaseUrl if govpressMode else "/" + org) %}
+    {% set baseUrl = dPlusBaseUrl if dPlusMode else (govpressBaseUrl if govpressMode else (opsBaseUrl if opsMode else "/" + org)) %}
     <header class="bg-slate-600 dark:bg-slate-900 text-white">
       <nav class="w-full flex items-center gap-4 p-6 border-b-4 border-slate-700 dark:border-slate-950">
         <a href="/" class="text-slate-300 hover:text-white transition-colors" aria-label="Back to home">
@@ -33,6 +33,10 @@
         <a href="/{{ org }}" class="inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-sm font-medium transition-colors bg-slate-500 text-white border-slate-400 hover:bg-slate-400">
           Exit GovPress mode
         </a>
+        {% elif opsMode %}
+        <a href="/{{ org }}" class="inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-sm font-medium transition-colors bg-slate-500 text-white border-slate-400 hover:bg-slate-400">
+          Exit Ops mode
+        </a>
         {% else %}
         <a href="/{{ org }}/d-plus" class="inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-sm font-medium transition-colors bg-purple-600 text-white border-purple-500 hover:bg-purple-500">
           <i class="bx bx-rocket"></i>
@@ -42,7 +46,14 @@
           <i class="bx bx-globe"></i>
           GovPress mode
         </a>
+        <a href="/{{ org }}/ops" class="inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-sm font-medium transition-colors bg-cyan-600 text-white border-cyan-500 hover:bg-cyan-500">
+          <i class="bx bx-server"></i>
+          Ops mode
+        </a>
         {% endif %}
+        <a href="/{{ org }}/settings" class="text-slate-200 hover:text-white transition-colors p-1 rounded-lg hover:bg-slate-500 dark:hover:bg-slate-700" aria-label="Email settings">
+          <i class="bx bx-envelope text-2xl"></i>
+        </a>
         <button id="theme-toggle" aria-label="Toggle dark mode"
           class="text-slate-200 hover:text-white transition-colors p-1 rounded-lg hover:bg-slate-500 dark:hover:bg-slate-700">
           <i id="theme-icon" class="bx text-2xl"></i>
@@ -53,12 +64,17 @@
     {% if dPlusMode %}
     <div class="bg-purple-600 dark:bg-purple-700 border-b-4 border-purple-800 dark:border-purple-900 px-6 py-4 text-white font-semibold text-base flex items-center gap-2">
       <i class="bx bx-info-circle text-xl"></i>
-      This dashboard shows only repos not marked GovPress.
+      This dashboard shows only repos marked D+, delivery-plus, or internal.
     </div>
     {% elif govpressMode %}
     <div class="bg-orange-600 dark:bg-orange-700 border-b-4 border-orange-800 dark:border-orange-900 px-6 py-4 text-white font-semibold text-base flex items-center gap-2">
       <i class="bx bx-info-circle text-xl"></i>
       This dashboard shows only repos marked GovPress.
+    </div>
+    {% elif opsMode %}
+    <div class="bg-cyan-600 dark:bg-cyan-700 border-b-4 border-cyan-800 dark:border-cyan-900 px-6 py-4 text-white font-semibold text-base flex items-center gap-2">
+      <i class="bx bx-info-circle text-xl"></i>
+      This dashboard shows only repos marked dalmatian or tech-ops.
     </div>
     {% endif %}
 
@@ -304,10 +320,6 @@
                 <p class="font-semibold">{{ repo.openBotPrCount }}</p>
               </div>
               <div>
-                <span class="text-slate-400 dark:text-slate-400 text-xs uppercase tracking-wide">Last bot PR closed</span>
-                <p class="font-semibold">{{ repo.mostRecentBotPrClosedAt or "—" }}</p>
-              </div>
-              <div>
                 <span class="text-slate-400 dark:text-slate-400 text-xs uppercase tracking-wide">Updated at</span>
                 <p class="font-semibold">{{ repo.updatedAt }}</p>
               </div>
@@ -327,6 +339,13 @@
                 <span class="text-slate-400 dark:text-slate-400 text-xs uppercase tracking-wide">Oldest open issue</span>
                 <p class="font-semibold">{{ repo.oldestOpenIssueOpenedAt }}</p>
               </div>
+            </div>
+
+            <!-- Last bot PR closed -->
+            <div class="mx-4 flex items-center gap-2 rounded border px-3 py-1.5 text-xs {% if repo.botPrStale %}bg-orange-50 dark:bg-orange-950/30 border-orange-400 dark:border-orange-700 border-2{% else %}border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/50{% endif %}">
+              <i class="bx bx-bot text-sm {% if repo.botPrStale %}text-orange-500 dark:text-orange-400{% else %}text-slate-400 dark:text-slate-500{% endif %}"></i>
+              <span class="{% if repo.botPrStale %}text-orange-600 dark:text-orange-400{% else %}text-slate-400 dark:text-slate-500{% endif %} uppercase tracking-wide font-medium">Last bot PR closed</span>
+              <span class="font-semibold {% if repo.botPrStale %}text-orange-700 dark:text-orange-300{% else %}text-slate-700 dark:text-slate-200{% endif %}">{{ repo.mostRecentBotPrClosedAt or "—" }}</span>
             </div>
 
             <!-- Dependencies -->

--- a/index.njk
+++ b/index.njk
@@ -134,6 +134,7 @@
             {{macros.sortableCardHeader("Updated at", "updatedAt", sortDirection, sortBy, baseUrl, alertFilter, tag)}}
             {{macros.sortableCardHeader("Most recent PR", "mostRecentPrOpenedAt", sortDirection, sortBy, baseUrl, alertFilter, tag)}}
             {{macros.sortableCardHeader("Oldest open PR", "oldestOpenPrOpenedAt", sortDirection, sortBy, baseUrl, alertFilter, tag)}}
+            {{macros.sortableCardHeader("Last bot PR closed", "mostRecentBotPrClosedAt", sortDirection, sortBy, baseUrl, alertFilter, tag)}}
             {{macros.sortableCardHeader("Most recent issue", "mostRecentIssueOpenedAt", sortDirection, sortBy, baseUrl, alertFilter, tag)}}
             {{macros.sortableCardHeader("Oldest open issue", "oldestOpenIssueOpenedAt", sortDirection, sortBy, baseUrl, alertFilter, tag)}}
           </div>
@@ -301,6 +302,10 @@
               <div>
                 <span class="text-slate-400 dark:text-slate-400 text-xs uppercase tracking-wide">Bot PRs</span>
                 <p class="font-semibold">{{ repo.openBotPrCount }}</p>
+              </div>
+              <div>
+                <span class="text-slate-400 dark:text-slate-400 text-xs uppercase tracking-wide">Last bot PR closed</span>
+                <p class="font-semibold">{{ repo.mostRecentBotPrClosedAt or "—" }}</p>
               </div>
               <div>
                 <span class="text-slate-400 dark:text-slate-400 text-xs uppercase tracking-wide">Updated at</span>

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "date-fns": "^4.1.0",
         "express": "^5.0.0",
         "express-session": "^1.19.0",
+        "nodemailer": "^9.0.3",
         "nunjucks": "^3.2.4",
         "openid-client": "^6.8.4",
         "undici": "^6.19.8"
@@ -2313,6 +2314,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
+      "integrity": "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/normalize-path": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "format": "prettier --write .",
     "seed": "npm run seed:repos && npm run seed:lifetimes",
     "seed:repos": "node --env-file=.env ./seed/repos.js",
-    "seed:lifetimes": "node --env-file=.env ./seed/lifetimes.js"
+    "seed:lifetimes": "node --env-file=.env ./seed/lifetimes.js",
+    "notify:slack": "node --env-file=.env ./script/notify-slack-stale-bot-prs.js",
+    "notify:email": "node --env-file=.env ./script/notify-email-subscriptions.js"
   },
   "author": "dxw",
   "license": "MIT",
@@ -27,6 +29,7 @@
     "date-fns": "^4.1.0",
     "express": "^5.0.0",
     "express-session": "^1.19.0",
+    "nodemailer": "^9.0.3",
     "nunjucks": "^3.2.4",
     "openid-client": "^6.8.4",
     "undici": "^6.19.8"

--- a/script/notify-email-subscriptions.js
+++ b/script/notify-email-subscriptions.js
@@ -1,0 +1,166 @@
+import nodemailer from "nodemailer";
+import { TowtruckDatabase } from "../db/index.js";
+import { mapRepoFromStorageToUi } from "../utils/index.js";
+import { filterByTags } from "../utils/tagFiltering.js";
+
+const SMTP_HOST = process.env.SMTP_HOST;
+const SMTP_PORT = process.env.SMTP_PORT || 587;
+const SMTP_USER = process.env.SMTP_USER;
+const SMTP_PASS = process.env.SMTP_PASS;
+const EMAIL_FROM = process.env.EMAIL_FROM || "towtruck@dxw.com";
+
+/**
+ * Creates a nodemailer transport
+ */
+const createTransport = () => {
+  return nodemailer.createTransport({
+    host: SMTP_HOST,
+    port: Number(SMTP_PORT),
+    secure: Number(SMTP_PORT) === 465,
+    auth: {
+      user: SMTP_USER,
+      pass: SMTP_PASS,
+    },
+  });
+};
+
+/**
+ * Gets repos matching a subscription's criteria
+ * @param {object} subscription
+ * @param {object[]} allRepos
+ * @returns {object[]}
+ */
+export const getMatchingRepos = (subscription, allRepos) => {
+  let matchedRepos = [];
+
+  // Filter by tags
+  if (subscription.tags && subscription.tags.length) {
+    const tagMatched = filterByTags(allRepos, subscription.tags);
+    matchedRepos.push(...tagMatched);
+  }
+
+  // Filter by critical alerts
+  if (subscription.criticalAlerts) {
+    const criticalRepos = allRepos.filter((repo) => (repo.criticalSeverityAlerts ?? 0) > 0);
+    criticalRepos.forEach((repo) => {
+      if (!matchedRepos.some((r) => r.name === repo.name)) {
+        matchedRepos.push(repo);
+      }
+    });
+  }
+
+  return matchedRepos;
+};
+
+/**
+ * Builds an HTML email body from the matched repos
+ * @param {object} subscription
+ * @param {object[]} repos
+ * @returns {string}
+ */
+export const buildEmailBody = (subscription, repos) => {
+  if (!repos.length) {
+    return `<p>No repos currently match your subscription criteria for <strong>${subscription.org}</strong>.</p>
+<p>Your settings: ${subscription.tags.length ? `Tags: ${subscription.tags.join(", ")}` : ""}${subscription.criticalAlerts ? " | Critical alerts: enabled" : ""}</p>`;
+  }
+
+  const repoRows = repos.map((repo) => {
+    const alerts = repo.criticalSeverityAlerts
+      ? `<span style="color: #dc2626; font-weight: bold;">${repo.criticalSeverityAlerts} critical</span>`
+      : "<span style=\"color: #6b7280;\">0 critical</span>";
+
+    const tags = (repo.topics || []).join(", ");
+
+    return `<tr>
+      <td style="padding: 8px; border-bottom: 1px solid #e2e8f0;"><a href="${repo.htmlUrl}">${repo.name}</a></td>
+      <td style="padding: 8px; border-bottom: 1px solid #e2e8f0;">${alerts} / ${repo.totalOpenAlerts ?? 0} total</td>
+      <td style="padding: 8px; border-bottom: 1px solid #e2e8f0;">${repo.openBotPrCount ?? 0} bot PRs, ${repo.openPrCount ?? 0} total</td>
+      <td style="padding: 8px; border-bottom: 1px solid #e2e8f0;">${tags}</td>
+    </tr>`;
+  });
+
+  return `<h2>Weekly Towtruck Report — ${subscription.org}</h2>
+<p>Here are the repos matching your subscription (${repos.length} repo${repos.length === 1 ? "" : "s"}):</p>
+<table style="border-collapse: collapse; width: 100%; font-size: 14px;">
+  <thead>
+    <tr style="background: #f1f5f9;">
+      <th style="padding: 8px; text-align: left; border-bottom: 2px solid #cbd5e1;">Repo</th>
+      <th style="padding: 8px; text-align: left; border-bottom: 2px solid #cbd5e1;">Alerts</th>
+      <th style="padding: 8px; text-align: left; border-bottom: 2px solid #cbd5e1;">PRs</th>
+      <th style="padding: 8px; text-align: left; border-bottom: 2px solid #cbd5e1;">Tags</th>
+    </tr>
+  </thead>
+  <tbody>
+    ${repoRows.join("\n    ")}
+  </tbody>
+</table>
+<p style="margin-top: 16px; font-size: 12px; color: #6b7280;">
+  Your settings: ${subscription.tags.length ? `Tags: ${subscription.tags.join(", ")}` : "No tag filter"}${subscription.criticalAlerts ? " | Critical alerts: enabled" : ""}
+</p>`;
+};
+
+/**
+ * Sends email updates for all subscriptions
+ */
+const main = async () => {
+  if (!SMTP_HOST || !SMTP_USER || !SMTP_PASS) {
+    console.error("Error: SMTP_HOST, SMTP_USER, and SMTP_PASS environment variables are required.");
+    process.exit(1);
+  }
+
+  const db = new TowtruckDatabase();
+  const allSubscriptions = db.getAllEmailSubscriptions();
+
+  const subscriptionList = Object.values(allSubscriptions)
+    .map((sub) => sub.preferences)
+    .filter(Boolean);
+
+  if (!subscriptionList.length) {
+    console.info("No email subscriptions found. Nothing to send.");
+    return;
+  }
+
+  console.info(`Processing ${subscriptionList.length} email subscription(s)...`);
+
+  const transport = createTransport();
+
+  for (const subscription of subscriptionList) {
+    const persistedRepoData = db.getAllRepositoriesForOrg(subscription.org);
+    const persistedLifetimeData = db.getAllDependencies();
+    const { repos } = mapRepoFromStorageToUi(persistedRepoData, persistedLifetimeData);
+
+    const matchedRepos = getMatchingRepos(subscription, repos);
+
+    // Skip sending if no criteria matched and no repos found
+    if (!subscription.tags.length && !subscription.criticalAlerts) {
+      console.info(`  Skipping ${subscription.userEmail} — no criteria configured.`);
+      continue;
+    }
+
+    const html = buildEmailBody(subscription, matchedRepos);
+    const subject = matchedRepos.length
+      ? `Towtruck: ${matchedRepos.length} repo${matchedRepos.length === 1 ? "" : "s"} need attention (${subscription.org})`
+      : `Towtruck: All clear for ${subscription.org}`;
+
+    try {
+      await transport.sendMail({
+        from: EMAIL_FROM,
+        to: subscription.userEmail,
+        subject,
+        html,
+      });
+      console.info(`  ✓ Sent to ${subscription.userEmail} (${matchedRepos.length} repos)`);
+    } catch (error) {
+      console.error(`  ✗ Failed to send to ${subscription.userEmail}:`, error.message);
+    }
+  }
+
+  console.info("Done!");
+};
+
+const isDirectExecution = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/^.*\//, ""));
+
+if (isDirectExecution) {
+  await main();
+}
+

--- a/script/notify-email-subscriptions.test.js
+++ b/script/notify-email-subscriptions.test.js
@@ -1,0 +1,74 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { getMatchingRepos, buildEmailBody } from "./notify-email-subscriptions.js";
+
+describe("getMatchingRepos", () => {
+  const allRepos = [
+    { name: "repo-a", topics: ["govpress", "wordpress"], criticalSeverityAlerts: 2, totalOpenAlerts: 5 },
+    { name: "repo-b", topics: ["delivery-plus"], criticalSeverityAlerts: 0, totalOpenAlerts: 1 },
+    { name: "repo-c", topics: ["govpress"], criticalSeverityAlerts: 1, totalOpenAlerts: 3 },
+    { name: "repo-d", topics: ["internal"], criticalSeverityAlerts: 0, totalOpenAlerts: 0 },
+  ];
+
+  it("returns repos matching selected tags", () => {
+    const subscription = { tags: ["govpress"], criticalAlerts: false };
+    const result = getMatchingRepos(subscription, allRepos);
+    assert.deepStrictEqual(result.map((r) => r.name), ["repo-a", "repo-c"]);
+  });
+
+  it("returns repos with critical alerts when criticalAlerts is enabled", () => {
+    const subscription = { tags: [], criticalAlerts: true };
+    const result = getMatchingRepos(subscription, allRepos);
+    assert.deepStrictEqual(result.map((r) => r.name), ["repo-a", "repo-c"]);
+  });
+
+  it("combines tag and critical alert filters without duplicates", () => {
+    const subscription = { tags: ["delivery-plus"], criticalAlerts: true };
+    const result = getMatchingRepos(subscription, allRepos);
+    assert.deepStrictEqual(result.map((r) => r.name), ["repo-b", "repo-a", "repo-c"]);
+  });
+
+  it("returns empty array when no criteria match", () => {
+    const subscription = { tags: ["nonexistent"], criticalAlerts: false };
+    const result = getMatchingRepos(subscription, allRepos);
+    assert.deepStrictEqual(result, []);
+  });
+
+  it("returns empty array when no criteria are set", () => {
+    const subscription = { tags: [], criticalAlerts: false };
+    const result = getMatchingRepos(subscription, allRepos);
+    assert.deepStrictEqual(result, []);
+  });
+});
+
+describe("buildEmailBody", () => {
+  it("returns a no-match message when repos array is empty", () => {
+    const subscription = { org: "dxw", tags: ["govpress"], criticalAlerts: false };
+    const html = buildEmailBody(subscription, []);
+    assert.ok(html.includes("No repos currently match"));
+    assert.ok(html.includes("dxw"));
+  });
+
+  it("returns an HTML table when repos are provided", () => {
+    const subscription = { org: "dxw", tags: ["govpress"], criticalAlerts: true };
+    const repos = [
+      {
+        name: "my-repo",
+        htmlUrl: "https://github.com/dxw/my-repo",
+        criticalSeverityAlerts: 3,
+        totalOpenAlerts: 7,
+        openBotPrCount: 2,
+        openPrCount: 4,
+        topics: ["govpress", "wordpress"],
+      },
+    ];
+    const html = buildEmailBody(subscription, repos);
+    assert.ok(html.includes("Weekly Towtruck Report"));
+    assert.ok(html.includes("my-repo"));
+    assert.ok(html.includes("3 critical"));
+    assert.ok(html.includes("7 total"));
+    assert.ok(html.includes("2 bot PRs"));
+    assert.ok(html.includes("govpress, wordpress"));
+  });
+});
+

--- a/script/notify-slack-stale-bot-prs.js
+++ b/script/notify-slack-stale-bot-prs.js
@@ -1,0 +1,91 @@
+import { TowtruckDatabase } from "../db/index.js";
+import { mapRepoFromStorageToUi } from "../utils/index.js";
+
+const SLACK_WEBHOOK_URL = process.env.SLACK_WEBHOOK_URL;
+const SLACK_CHANNEL = process.env.SLACK_CHANNEL;
+
+/**
+ * Collects all repos with stale bot PRs (open bot PRs with no closed bot PR in last 6 months)
+ * @returns {{ org: string, name: string, openBotPrCount: number, mostRecentBotPrClosedAt: string | null }[]}
+ */
+const getStaleRepos = () => {
+  const db = new TowtruckDatabase();
+  const persistedRepoData = db.getAllRepositories();
+  const persistedLifetimeData = db.getAllDependencies();
+  const { repos } = mapRepoFromStorageToUi(persistedRepoData, persistedLifetimeData);
+
+  return repos
+    .filter((repo) => repo.botPrStale)
+    .map((repo) => ({
+      name: repo.name,
+      openBotPrCount: repo.openBotPrCount,
+      mostRecentBotPrClosedAt: repo.mostRecentBotPrClosedAt,
+      htmlUrl: repo.htmlUrl,
+    }));
+};
+
+/**
+ * Builds a Slack message payload from the stale repos
+ * @param {{ name: string, mostRecentBotPrClosedAt: string | null, htmlUrl: string }[]} staleRepos
+ * @returns {object | null}
+ */
+export const buildSlackPayload = (staleRepos) => {
+  if (!staleRepos.length) {
+    return null;
+  }
+
+  const repoLines = staleRepos.map((repo) => {
+    const lastClosed = repo.mostRecentBotPrClosedAt || "never";
+    return `• <${repo.htmlUrl}|${repo.name}> — last bot PR closed: ${lastClosed}`;
+  });
+
+  const payload = {
+    text: `⚠️ *Stale Bot PRs Report*\n\n${staleRepos.length} repo${staleRepos.length === 1 ? " has" : "s have"} not had a bot PR closed in over 6 months:\n\n${repoLines.join("\n")}`,
+  };
+  if (SLACK_CHANNEL) payload.channel = SLACK_CHANNEL;
+  return payload;
+};
+
+/**
+ * Posts a message to Slack via Incoming Webhook
+ * @param {object} payload
+ */
+const postToSlack = async (payload) => {
+  const response = await fetch(SLACK_WEBHOOK_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Slack webhook failed (${response.status}): ${body}`);
+  }
+};
+
+const main = async () => {
+  if (!SLACK_WEBHOOK_URL) {
+    console.error("Error: SLACK_WEBHOOK_URL environment variable is required.");
+    process.exit(1);
+  }
+
+  console.info("Checking for stale bot PRs...");
+  const staleRepos = getStaleRepos();
+  console.info(`Found ${staleRepos.length} repo(s) with stale bot PRs.`);
+
+  const payload = buildSlackPayload(staleRepos);
+  if (!payload) {
+    console.info("Nothing to report. Skipping Slack post.");
+    return;
+  }
+
+  console.info("Posting to Slack...");
+  await postToSlack(payload);
+  console.info("Done!");
+};
+
+const isDirectExecution = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/^.*\//, ""));
+
+if (isDirectExecution) {
+  await main();
+}

--- a/script/notify-slack-stale-bot-prs.test.js
+++ b/script/notify-slack-stale-bot-prs.test.js
@@ -1,0 +1,65 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { buildSlackPayload } from "./notify-slack-stale-bot-prs.js";
+
+describe("buildSlackPayload", () => {
+  it("returns null when there are no stale repos", () => {
+    const payload = buildSlackPayload([]);
+
+    assert.strictEqual(payload, null);
+  });
+
+  it("returns a warning message listing stale repos", () => {
+    const staleRepos = [
+      {
+        name: "my-repo",
+        mostRecentBotPrClosedAt: "01/01/24",
+        htmlUrl: "https://github.com/dxw/my-repo",
+      },
+    ];
+
+    const payload = buildSlackPayload(staleRepos);
+
+    assert.ok(payload.text.includes("Stale Bot PRs Report"));
+    assert.ok(payload.text.includes("1 repo has"));
+    assert.ok(payload.text.includes("my-repo"));
+    assert.ok(payload.text.includes("last bot PR closed: 01/01/24"));
+  });
+
+  it("pluralises correctly for multiple repos", () => {
+    const staleRepos = [
+      {
+        name: "repo-a",
+        mostRecentBotPrClosedAt: null,
+        htmlUrl: "https://github.com/dxw/repo-a",
+      },
+      {
+        name: "repo-b",
+        mostRecentBotPrClosedAt: "15/03/24",
+        htmlUrl: "https://github.com/dxw/repo-b",
+      },
+    ];
+
+    const payload = buildSlackPayload(staleRepos);
+
+    assert.ok(payload.text.includes("2 repos have"));
+    assert.ok(payload.text.includes("repo-a"));
+    assert.ok(payload.text.includes("last bot PR closed: never"));
+    assert.ok(payload.text.includes("repo-b"));
+    assert.ok(payload.text.includes("last bot PR closed: 15/03/24"));
+  });
+
+  it("shows never when mostRecentBotPrClosedAt is null", () => {
+    const staleRepos = [
+      {
+        name: "no-closed",
+        mostRecentBotPrClosedAt: null,
+        htmlUrl: "https://github.com/dxw/no-closed",
+      },
+    ];
+
+    const payload = buildSlackPayload(staleRepos);
+
+    assert.ok(payload.text.includes("last bot PR closed: never"));
+  });
+});

--- a/settings.njk
+++ b/settings.njk
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <title>Towtruck — Settings</title>
+    <meta name="description" content="" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link href='https://unpkg.com/boxicons@2.1.4/css/boxicons.min.css' rel='stylesheet'>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>tailwind.config = { darkMode: 'class' }</script>
+    <script>
+      if (localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+        document.documentElement.classList.add('dark');
+      }
+    </script>
+  </head>
+  <body class="bg-slate-200 text-slate-900 dark:bg-slate-950 dark:text-slate-100">
+    <header class="bg-slate-600 dark:bg-slate-900 text-white">
+      <nav class="w-full flex items-center gap-4 p-6 border-b-4 border-slate-700 dark:border-slate-950">
+        <a href="/{{ org }}" class="text-slate-300 hover:text-white transition-colors" aria-label="Back to dashboard">
+          <i class="bx bx-arrow-back text-2xl"></i>
+        </a>
+        <h1 class="text-3xl font-bold flex-1">Email Updates</h1>
+        <button id="theme-toggle" aria-label="Toggle dark mode"
+          class="text-slate-200 hover:text-white transition-colors p-1 rounded-lg hover:bg-slate-500 dark:hover:bg-slate-700">
+          <i id="theme-icon" class="bx text-2xl"></i>
+        </button>
+      </nav>
+    </header>
+
+    <div class="container mx-auto flex flex-col mt-6 space-y-6 max-w-2xl">
+
+      {% if saved %}
+      <div class="bg-green-100 dark:bg-green-900/40 border border-green-400 dark:border-green-700 rounded-lg px-4 py-3 text-green-800 dark:text-green-200 text-sm flex items-center gap-2">
+        <i class="bx bx-check-circle text-lg"></i>
+        Email subscription saved successfully.
+      </div>
+      {% endif %}
+
+      {% if deleted %}
+      <div class="bg-yellow-100 dark:bg-yellow-900/40 border border-yellow-400 dark:border-yellow-700 rounded-lg px-4 py-3 text-yellow-800 dark:text-yellow-200 text-sm flex items-center gap-2">
+        <i class="bx bx-info-circle text-lg"></i>
+        Email subscription removed.
+      </div>
+      {% endif %}
+
+      <div class="bg-slate-100 dark:bg-slate-900 rounded-lg border-b-4 border-slate-300 dark:border-slate-950">
+
+        <div class="p-6 space-y-4">
+          <p class="text-sm text-slate-600 dark:text-slate-300">
+            Get a weekly email digest sent to <span class="font-semibold">{{ email }}</span> with updates on repos matching your criteria.
+          </p>
+
+          <form method="POST" action="/{{ org }}/settings/email-subscription" class="space-y-6">
+
+            <!-- Critical alerts toggle -->
+            <div class="flex items-center gap-3">
+              <input type="checkbox" id="criticalAlerts" name="criticalAlerts"
+                class="w-5 h-5 rounded border-slate-300 dark:border-slate-600 text-red-600 focus:ring-red-500"
+                {% if subscription.criticalAlerts %}checked{% endif %} />
+              <label for="criticalAlerts" class="text-sm font-medium">
+                <span class="text-red-600 dark:text-red-400 font-semibold">Critical alerts</span>
+                — include repos with critical security vulnerabilities
+              </label>
+            </div>
+
+            <!-- Tag selection -->
+            <div>
+              <p class="text-sm font-medium mb-2">Subscribe to repos with these tags:</p>
+              {% if allTopics.length %}
+              <div class="flex flex-wrap gap-2">
+                {% for topic in allTopics %}
+                <label class="inline-flex items-center gap-1.5 cursor-pointer">
+                  <input type="checkbox" name="tags" value="{{ topic }}"
+                    class="w-4 h-4 rounded border-slate-300 dark:border-slate-600 text-slate-700 focus:ring-slate-500"
+                    {% if topic in subscription.tags %}checked{% endif %} />
+                  <span class="text-sm rounded-full py-0.5 px-2 bg-slate-200 dark:bg-slate-800 text-slate-600 dark:text-slate-300">{{ topic }}</span>
+                </label>
+                {% endfor %}
+              </div>
+              {% else %}
+              <p class="text-sm text-slate-400 italic">No tags found across repos.</p>
+              {% endif %}
+            </div>
+
+            <!-- Submit -->
+            <div class="flex items-center gap-3">
+              <button type="submit" class="inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium bg-slate-700 text-white hover:bg-slate-600 dark:bg-slate-200 dark:text-slate-900 dark:hover:bg-slate-300 transition-colors">
+                <i class="bx bx-save"></i>
+                Save subscription
+              </button>
+            </div>
+          </form>
+
+          {% if subscription.tags.length or subscription.criticalAlerts %}
+          <div class="border-t border-slate-200 dark:border-slate-700 pt-4">
+            <form method="POST" action="/{{ org }}/settings/email-subscription/delete">
+              <button type="submit" class="inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium bg-red-100 text-red-700 border border-red-300 hover:bg-red-200 dark:bg-red-950 dark:text-red-300 dark:border-red-800 dark:hover:bg-red-900 transition-colors">
+                <i class="bx bx-trash"></i>
+                Remove subscription
+              </button>
+            </form>
+          </div>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+
+    <script>
+      const toggle = document.getElementById('theme-toggle');
+      const icon = document.getElementById('theme-icon');
+      function applyTheme() {
+        const isDark = document.documentElement.classList.contains('dark');
+        icon.className = 'bx text-2xl ' + (isDark ? 'bx-sun' : 'bx-moon');
+      }
+      applyTheme();
+      toggle.addEventListener('click', () => {
+        document.documentElement.classList.toggle('dark');
+        localStorage.theme = document.documentElement.classList.contains('dark') ? 'dark' : 'light';
+        applyTheme();
+      });
+    </script>
+  </body>
+</html>
+

--- a/utils/githubApi/fetchAllRepos.test.js
+++ b/utils/githubApi/fetchAllRepos.test.js
@@ -25,6 +25,9 @@ describe("fetchForRepo", () => {
       "https://some.api/pulls": {
         data: [],
       },
+      "https://some.api/pulls?state=closed&sort=updated&direction=desc&per_page=100": {
+        data: [],
+      },
     };
 
     t.mock.method(octokit, "request", async (url) =>
@@ -81,6 +84,9 @@ describe("fetchForRepo", () => {
       "https://some.api/pulls": {
         data: [],
       },
+      "https://some.api/pulls?state=closed&sort=updated&direction=desc&per_page=100": {
+        data: [],
+      },
     };
 
     t.mock.method(octokit, "request", async (url) =>
@@ -129,6 +135,14 @@ describe("fetchForRepo", () => {
           },
         ],
       },
+      "https://some.api/pulls?state=closed&sort=updated&direction=desc&per_page=100": {
+        data: [
+          {
+            user: { login: "renovate[bot]" },
+            closed_at: "2024-09-01T10:00:00Z",
+          },
+        ],
+      },
     };
 
     t.mock.method(octokit, "request", async (url) =>
@@ -156,6 +170,7 @@ describe("fetchForRepo", () => {
       openBotPrCount: 1,
       oldestOpenPrOpenedAt: new Date("2024-01-01T12:34:56.789Z"),
       mostRecentPrOpenedAt: new Date("2024-10-10T11:22:33.444Z"),
+      mostRecentBotPrClosedAt: new Date("2024-09-01T10:00:00Z"),
     };
 
     const actual = await fetchForRepo(repository, octokit);
@@ -184,6 +199,9 @@ describe("fetchForRepo", () => {
         ],
       },
       "https://some.api/pulls": {
+        data: [],
+      },
+      "https://some.api/pulls?state=closed&sort=updated&direction=desc&per_page=100": {
         data: [],
       },
     };
@@ -217,6 +235,9 @@ describe("fetchForRepo", () => {
         data: [],
       },
       "https://some.api/pulls": {
+        data: [],
+      },
+      "https://some.api/pulls?state=closed&sort=updated&direction=desc&per_page=100": {
         data: [],
       },
       "/repos/{owner}/{repo}/dependabot/alerts": {

--- a/utils/githubApi/fetchOpenPrs.js
+++ b/utils/githubApi/fetchOpenPrs.js
@@ -5,14 +5,43 @@
  * @returns {Promise<number>}
  */
 export const getOpenPRsForRepo = async ({ octokit, repository }) => {
-  return octokit.request(repository.pulls_url).then(handlePrsApiResponse)
-    .catch((error) => {
-      console.error(error);
-      return {};
-    });;
+  const pullsUrl = repository.pulls_url.replace("{/number}", "");
+
+  return Promise.all([
+    octokit.request(repository.pulls_url).then(handlePrsApiResponse),
+    octokit.request(`${pullsUrl}?state=closed&sort=updated&direction=desc&per_page=100`)
+      .then(({ data }) => handleClosedBotPrsResponse(data)),
+  ]).then(([openPrInfo, closedBotPrInfo]) => ({
+    ...openPrInfo,
+    ...closedBotPrInfo,
+  })).catch((error) => {
+    console.error(error);
+    return {};
+  });
 };
 
 const depdencyUpdateBots = ["renovate[bot]", "dependabot[bot]"];
+
+/**
+ * Returns the most recent closed_at date among PRs authored by dependency update bots
+ * @param {any[]} data
+ * @returns {{ mostRecentBotPrClosedAt: Date | null }}
+ */
+export const handleClosedBotPrsResponse = (data) => {
+  const mostRecentBotPrClosedAt = data.reduce((latestDate, pr) => {
+    if (!depdencyUpdateBots.includes(pr?.user?.login)) {
+      return latestDate;
+    }
+
+    const closedAt = new Date(pr.closed_at);
+    if (!latestDate || latestDate < closedAt) {
+      return closedAt;
+    }
+    return latestDate;
+  }, null);
+
+  return { mostRecentBotPrClosedAt };
+};
 
 /**
  * Returns the length of the PRs array or 0 if there are no PRs

--- a/utils/githubApi/fetchOpenPrs.test.js
+++ b/utils/githubApi/fetchOpenPrs.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import expect from "node:assert";
-import { handlePrsApiResponse } from "./fetchOpenPrs.js";
+import { handlePrsApiResponse, handleClosedBotPrsResponse } from "./fetchOpenPrs.js";
 
 describe("handlePrsApiResponse", () => {
   describe("openPrCount", () => {
@@ -105,3 +105,43 @@ describe("handlePrsApiResponse", () => {
     expect.deepStrictEqual(actual.oldestOpenPrOpenedAt, new Date(openPr1.created_at));
   });
 });
+
+describe("handleClosedBotPrsResponse", () => {
+  it("returns null if there are no closed PRs", () => {
+    const actual = handleClosedBotPrsResponse([]);
+
+    expect.strictEqual(actual.mostRecentBotPrClosedAt, null);
+  });
+
+  it("returns null if there are no bot PRs among closed PRs", () => {
+    const humanPr = { user: { login: "rich" }, closed_at: "2024-03-01T12:00:00Z" };
+    const actual = handleClosedBotPrsResponse([humanPr]);
+
+    expect.strictEqual(actual.mostRecentBotPrClosedAt, null);
+  });
+
+  it("returns the closed_at date of a renovate bot PR", () => {
+    const renovatePr = { user: { login: "renovate[bot]" }, closed_at: "2024-03-01T12:00:00Z" };
+    const actual = handleClosedBotPrsResponse([renovatePr]);
+
+    expect.deepStrictEqual(actual.mostRecentBotPrClosedAt, new Date("2024-03-01T12:00:00Z"));
+  });
+
+  it("returns the closed_at date of a dependabot PR", () => {
+    const dependabotPr = { user: { login: "dependabot[bot]" }, closed_at: "2024-04-15T10:00:00Z" };
+    const actual = handleClosedBotPrsResponse([dependabotPr]);
+
+    expect.deepStrictEqual(actual.mostRecentBotPrClosedAt, new Date("2024-04-15T10:00:00Z"));
+  });
+
+  it("returns the most recent closed_at among multiple bot PRs", () => {
+    const olderRenovatePr = { user: { login: "renovate[bot]" }, closed_at: "2024-01-01T12:00:00Z" };
+    const newerDependabotPr = { user: { login: "dependabot[bot]" }, closed_at: "2024-05-01T12:00:00Z" };
+    const humanPr = { user: { login: "rich" }, closed_at: "2024-06-01T12:00:00Z" };
+
+    const actual = handleClosedBotPrsResponse([olderRenovatePr, newerDependabotPr, humanPr]);
+
+    expect.deepStrictEqual(actual.mostRecentBotPrClosedAt, new Date("2024-05-01T12:00:00Z"));
+  });
+});
+

--- a/utils/index.js
+++ b/utils/index.js
@@ -152,6 +152,12 @@ export const mapRepoFromStorageToUi = (persistedData, persistedLifetimes, dateSt
 
     const languageColor = hashToTailwindColor(repo.main.language);
 
+    const sixMonthsAgo = new Date();
+    sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6);
+    const hasOpenBotPrs = (repo.pullRequests.openBotPrCount ?? 0) > 0;
+    const lastBotPrClosed = repo.pullRequests.mostRecentBotPrClosedAt ? new Date(repo.pullRequests.mostRecentBotPrClosedAt) : null;
+    const botPrStale = hasOpenBotPrs && (!lastBotPrClosed || lastBotPrClosed < sixMonthsAgo);
+
     return {
       ...repo.main,
       ...repo.dependabotAlerts,
@@ -166,6 +172,7 @@ export const mapRepoFromStorageToUi = (persistedData, persistedLifetimes, dateSt
       oldestOpenPrOpenedAtISO8601: repo.pullRequests.oldestOpenPrOpenedAt,
       mostRecentBotPrClosedAt,
       mostRecentBotPrClosedAtISO8601: repo.pullRequests.mostRecentBotPrClosedAt,
+      botPrStale,
       mostRecentIssueOpenedAt,
       mostRecentIssueOpenedAtISO8601: repo.issues.mostRecentIssueOpenedAt,
       oldestOpenIssueOpenedAt,

--- a/utils/index.js
+++ b/utils/index.js
@@ -146,6 +146,7 @@ export const mapRepoFromStorageToUi = (persistedData, persistedLifetimes, dateSt
 
     const mostRecentPrOpenedAt = repo.pullRequests.mostRecentPrOpenedAt && formatDate(repo.pullRequests.mostRecentPrOpenedAt, dateStyle);
     const oldestOpenPrOpenedAt = repo.pullRequests.oldestOpenPrOpenedAt && formatDate(repo.pullRequests.oldestOpenPrOpenedAt, dateStyle);
+    const mostRecentBotPrClosedAt = repo.pullRequests.mostRecentBotPrClosedAt && formatDate(repo.pullRequests.mostRecentBotPrClosedAt, dateStyle);
     const mostRecentIssueOpenedAt = repo.issues.mostRecentIssueOpenedAt && formatDate(repo.issues.mostRecentIssueOpenedAt, dateStyle);
     const oldestOpenIssueOpenedAt = repo.issues.oldestOpenIssueOpenedAt && formatDate(repo.issues.oldestOpenIssueOpenedAt, dateStyle);
 
@@ -163,6 +164,8 @@ export const mapRepoFromStorageToUi = (persistedData, persistedLifetimes, dateSt
       mostRecentPrOpenedAtISO8601: repo.pullRequests.mostRecentPrOpenedAt,
       oldestOpenPrOpenedAt,
       oldestOpenPrOpenedAtISO8601: repo.pullRequests.oldestOpenPrOpenedAt,
+      mostRecentBotPrClosedAt,
+      mostRecentBotPrClosedAtISO8601: repo.pullRequests.mostRecentBotPrClosedAt,
       mostRecentIssueOpenedAt,
       mostRecentIssueOpenedAtISO8601: repo.issues.mostRecentIssueOpenedAt,
       oldestOpenIssueOpenedAt,

--- a/utils/index.test.js
+++ b/utils/index.test.js
@@ -53,6 +53,7 @@ describe("mapRepoFromStorageToUi", () => {
         oldestOpenPrOpenedAtISO8601: "2022-02-02T00:00:00Z",
         mostRecentBotPrClosedAt: formatDate("2021-06-15T00:00:00Z"),
         mostRecentBotPrClosedAtISO8601: "2021-06-15T00:00:00Z",
+        botPrStale: false,
         mostRecentIssueOpenedAt: formatDate("2023-03-03T00:00:00Z"),
         mostRecentIssueOpenedAtISO8601: "2023-03-03T00:00:00Z",
         oldestOpenIssueOpenedAt: formatDate("2024-04-04T00:00:00Z"),
@@ -138,6 +139,7 @@ describe("mapRepoFromStorageToUi", () => {
         oldestOpenPrOpenedAtISO8601: "2022-02-02T00:00:00Z",
         mostRecentBotPrClosedAt: null,
         mostRecentBotPrClosedAtISO8601: null,
+        botPrStale: false,
         mostRecentIssueOpenedAt: formatDate("2023-03-03T00:00:00Z"),
         mostRecentIssueOpenedAtISO8601: "2023-03-03T00:00:00Z",
         oldestOpenIssueOpenedAt: formatDate("2024-04-04T00:00:00Z"),
@@ -163,6 +165,7 @@ describe("mapRepoFromStorageToUi", () => {
         oldestOpenPrOpenedAtISO8601: "2022-02-02T00:00:00Z",
         mostRecentBotPrClosedAt: null,
         mostRecentBotPrClosedAtISO8601: null,
+        botPrStale: false,
         mostRecentIssueOpenedAt: formatDate("2023-03-03T00:00:00Z"),
         mostRecentIssueOpenedAtISO8601: "2023-03-03T00:00:00Z",
         oldestOpenIssueOpenedAt: formatDate("2024-04-04T00:00:00Z"),
@@ -172,6 +175,148 @@ describe("mapRepoFromStorageToUi", () => {
     ];
 
     expect.deepEqual(mapRepoFromStorageToUi(persistedData).repos, expected);
+  });
+
+  it("sets botPrStale to true when repo has open bot PRs and last closed bot PR is older than 6 months", () => {
+    const sevenMonthsAgo = new Date();
+    sevenMonthsAgo.setMonth(sevenMonthsAgo.getMonth() - 7);
+
+    const persistedData = {
+      repo1: {
+        owner: "dxw",
+        main: {
+          name: "repo1",
+          description: "description1",
+          updatedAt: "2021-01-01T00:00:00Z",
+          htmlUrl: "http://url.com/repo1",
+          apiUrl: "http://api.com/repo1",
+          pullsUrl: "http://api.com/repo1/pulls",
+          issuesUrl: "http://api.com/repo1/issues",
+          language: null,
+          topics: [],
+        },
+        pullRequests: {
+          openBotPrCount: 2,
+          mostRecentPrOpenedAt: null,
+          oldestOpenPrOpenedAt: null,
+          mostRecentBotPrClosedAt: sevenMonthsAgo.toISOString(),
+        },
+        issues: {
+          openIssues: 0,
+          mostRecentIssueOpenedAt: null,
+          oldestOpenIssueOpenedAt: null,
+        },
+        dependencies: [],
+      },
+    };
+
+    const [repo] = mapRepoFromStorageToUi(persistedData, {}).repos;
+    expect.strictEqual(repo.botPrStale, true);
+  });
+
+  it("sets botPrStale to false when repo has open bot PRs but last closed bot PR is recent", () => {
+    const twoWeeksAgo = new Date();
+    twoWeeksAgo.setDate(twoWeeksAgo.getDate() - 14);
+
+    const persistedData = {
+      repo1: {
+        owner: "dxw",
+        main: {
+          name: "repo1",
+          description: "description1",
+          updatedAt: "2021-01-01T00:00:00Z",
+          htmlUrl: "http://url.com/repo1",
+          apiUrl: "http://api.com/repo1",
+          pullsUrl: "http://api.com/repo1/pulls",
+          issuesUrl: "http://api.com/repo1/issues",
+          language: null,
+          topics: [],
+        },
+        pullRequests: {
+          openBotPrCount: 1,
+          mostRecentPrOpenedAt: null,
+          oldestOpenPrOpenedAt: null,
+          mostRecentBotPrClosedAt: twoWeeksAgo.toISOString(),
+        },
+        issues: {
+          openIssues: 0,
+          mostRecentIssueOpenedAt: null,
+          oldestOpenIssueOpenedAt: null,
+        },
+        dependencies: [],
+      },
+    };
+
+    const [repo] = mapRepoFromStorageToUi(persistedData, {}).repos;
+    expect.strictEqual(repo.botPrStale, false);
+  });
+
+  it("sets botPrStale to false when repo has no open bot PRs", () => {
+    const persistedData = {
+      repo1: {
+        owner: "dxw",
+        main: {
+          name: "repo1",
+          description: "description1",
+          updatedAt: "2021-01-01T00:00:00Z",
+          htmlUrl: "http://url.com/repo1",
+          apiUrl: "http://api.com/repo1",
+          pullsUrl: "http://api.com/repo1/pulls",
+          issuesUrl: "http://api.com/repo1/issues",
+          language: null,
+          topics: [],
+        },
+        pullRequests: {
+          openBotPrCount: 0,
+          mostRecentPrOpenedAt: null,
+          oldestOpenPrOpenedAt: null,
+          mostRecentBotPrClosedAt: null,
+        },
+        issues: {
+          openIssues: 0,
+          mostRecentIssueOpenedAt: null,
+          oldestOpenIssueOpenedAt: null,
+        },
+        dependencies: [],
+      },
+    };
+
+    const [repo] = mapRepoFromStorageToUi(persistedData, {}).repos;
+    expect.strictEqual(repo.botPrStale, false);
+  });
+
+  it("sets botPrStale to true when repo has open bot PRs and no bot PR has ever been closed", () => {
+    const persistedData = {
+      repo1: {
+        owner: "dxw",
+        main: {
+          name: "repo1",
+          description: "description1",
+          updatedAt: "2021-01-01T00:00:00Z",
+          htmlUrl: "http://url.com/repo1",
+          apiUrl: "http://api.com/repo1",
+          pullsUrl: "http://api.com/repo1/pulls",
+          issuesUrl: "http://api.com/repo1/issues",
+          language: null,
+          topics: [],
+        },
+        pullRequests: {
+          openBotPrCount: 3,
+          mostRecentPrOpenedAt: null,
+          oldestOpenPrOpenedAt: null,
+          mostRecentBotPrClosedAt: null,
+        },
+        issues: {
+          openIssues: 0,
+          mostRecentIssueOpenedAt: null,
+          oldestOpenIssueOpenedAt: null,
+        },
+        dependencies: [],
+      },
+    };
+
+    const [repo] = mapRepoFromStorageToUi(persistedData, {}).repos;
+    expect.strictEqual(repo.botPrStale, true);
   });
 
   it("formats updatedAt as MM/DD/YYYY when dateStyle is MM/DD/YYYY", () => {

--- a/utils/index.test.js
+++ b/utils/index.test.js
@@ -22,6 +22,7 @@ describe("mapRepoFromStorageToUi", () => {
         pullRequests: {
           mostRecentPrOpenedAt: "2021-01-01T00:00:00Z",
           oldestOpenPrOpenedAt: "2022-02-02T00:00:00Z",
+          mostRecentBotPrClosedAt: "2021-06-15T00:00:00Z",
         },
         issues: {
           openIssues: 0,
@@ -50,6 +51,8 @@ describe("mapRepoFromStorageToUi", () => {
         mostRecentPrOpenedAtISO8601: "2021-01-01T00:00:00Z",
         oldestOpenPrOpenedAt: formatDate("2022-02-02T00:00:00Z"),
         oldestOpenPrOpenedAtISO8601: "2022-02-02T00:00:00Z",
+        mostRecentBotPrClosedAt: formatDate("2021-06-15T00:00:00Z"),
+        mostRecentBotPrClosedAtISO8601: "2021-06-15T00:00:00Z",
         mostRecentIssueOpenedAt: formatDate("2023-03-03T00:00:00Z"),
         mostRecentIssueOpenedAtISO8601: "2023-03-03T00:00:00Z",
         oldestOpenIssueOpenedAt: formatDate("2024-04-04T00:00:00Z"),
@@ -79,6 +82,7 @@ describe("mapRepoFromStorageToUi", () => {
         pullRequests: {
           mostRecentPrOpenedAt: "2021-01-01T00:00:00Z",
           oldestOpenPrOpenedAt: "2022-02-02T00:00:00Z",
+          mostRecentBotPrClosedAt: null,
         },
         issues: {
           openIssues: 0,
@@ -103,6 +107,7 @@ describe("mapRepoFromStorageToUi", () => {
         pullRequests: {
           mostRecentPrOpenedAt: "2021-01-01T00:00:00Z",
           oldestOpenPrOpenedAt: "2022-02-02T00:00:00Z",
+          mostRecentBotPrClosedAt: null,
         },
         issues: {
           openIssues: 0,
@@ -131,6 +136,8 @@ describe("mapRepoFromStorageToUi", () => {
         mostRecentPrOpenedAtISO8601: "2021-01-01T00:00:00Z",
         oldestOpenPrOpenedAt: formatDate("2022-02-02T00:00:00Z"),
         oldestOpenPrOpenedAtISO8601: "2022-02-02T00:00:00Z",
+        mostRecentBotPrClosedAt: null,
+        mostRecentBotPrClosedAtISO8601: null,
         mostRecentIssueOpenedAt: formatDate("2023-03-03T00:00:00Z"),
         mostRecentIssueOpenedAtISO8601: "2023-03-03T00:00:00Z",
         oldestOpenIssueOpenedAt: formatDate("2024-04-04T00:00:00Z"),
@@ -154,6 +161,8 @@ describe("mapRepoFromStorageToUi", () => {
         mostRecentPrOpenedAtISO8601: "2021-01-01T00:00:00Z",
         oldestOpenPrOpenedAt: formatDate("2022-02-02T00:00:00Z"),
         oldestOpenPrOpenedAtISO8601: "2022-02-02T00:00:00Z",
+        mostRecentBotPrClosedAt: null,
+        mostRecentBotPrClosedAtISO8601: null,
         mostRecentIssueOpenedAt: formatDate("2023-03-03T00:00:00Z"),
         mostRecentIssueOpenedAtISO8601: "2023-03-03T00:00:00Z",
         oldestOpenIssueOpenedAt: formatDate("2024-04-04T00:00:00Z"),

--- a/utils/sorting.js
+++ b/utils/sorting.js
@@ -77,6 +77,9 @@ export const sortByType = (repos, sortDirection, sortBy) => {
     case "oldestOpenPrOpenedAt":
       return sortByISO8601Timestamp(repos, sortDirection, "oldestOpenPrOpenedAtISO8601");
 
+    case "mostRecentBotPrClosedAt":
+      return sortByISO8601Timestamp(repos, sortDirection, "mostRecentBotPrClosedAtISO8601");
+
     case "mostRecentIssueOpenedAt":
       return sortByISO8601Timestamp(repos, sortDirection, "mostRecentIssueOpenedAtISO8601");
 

--- a/webhooks/pullRequests.test.js
+++ b/webhooks/pullRequests.test.js
@@ -33,6 +33,14 @@ describe("handleEvent", () => {
           },
         ],
       },
+      "https://some.api/pulls?state=closed&sort=updated&direction=desc&per_page=100": {
+        data: [
+          {
+            user: { login: "renovate[bot]" },
+            closed_at: "2024-09-15T08:00:00Z",
+          },
+        ],
+      },
     };
 
     t.mock.method(octokit, "request", async (url) =>
@@ -60,11 +68,12 @@ describe("handleEvent", () => {
       openBotPrCount: 1,
       oldestOpenPrOpenedAt: new Date("2024-01-01T12:34:56.789Z"),
       mostRecentPrOpenedAt: new Date("2024-10-10T11:22:33.444Z"),
+      mostRecentBotPrClosedAt: new Date("2024-09-15T08:00:00Z"),
     };
 
     await handleEvent(event, db);
 
-    expect.strictEqual(octokit.request.mock.callCount(), 1);
+    expect.strictEqual(octokit.request.mock.callCount(), 2);
 
     expect.strictEqual(db.saveToRepository.mock.callCount(), 1);
 


### PR DESCRIPTION
Features:
- Add email subscription settings page (/:org/settings) with tag and
  critical alerts filtering, sent to the user's auth email
- Add Slack integration for stale bot PR notifications (posts only when
  repos have not had a bot PR closed in over 6 months)
- Add Ops mode (/:org/ops) for repos tagged dalmatian or tech-ops
- Change D+ mode to include only repos tagged d-plus, delivery-plus,
  or internal (previously excluded govpress)
- Add nodemailer dependency for SMTP email sending
- Add email icon link in nav bar to access subscription settings
- Update stale bot PR panel styling to orange
- Add botPrStale computed flag with tests
- Add .gitignore entries for local setup docs"