### PR TITLE
Fix webhook handling, small tweaks

### DIFF
--- a/utils/index.js
+++ b/utils/index.js
@@ -148,6 +148,7 @@ export const mapRepoFromStorageToUi = (persistedData, persistedLifetimes, dateSt
 
     const mostRecentPrOpenedAt = repo.pullRequests.mostRecentPrOpenedAt && formatDate(repo.pullRequests.mostRecentPrOpenedAt, dateStyle);
     const oldestOpenPrOpenedAt = repo.pullRequests.oldestOpenPrOpenedAt && formatDate(repo.pullRequests.oldestOpenPrOpenedAt, dateStyle);
+    const mostRecentBotPrClosedAt = repo.pullRequests.mostRecentBotPrClosedAt && formatDate(repo.pullRequests.mostRecentBotPrClosedAt, dateStyle);
     const mostRecentIssueOpenedAt = repo.issues.mostRecentIssueOpenedAt && formatDate(repo.issues.mostRecentIssueOpenedAt, dateStyle);
     const oldestOpenIssueOpenedAt = repo.issues.oldestOpenIssueOpenedAt && formatDate(repo.issues.oldestOpenIssueOpenedAt, dateStyle);
 
@@ -165,6 +166,7 @@ export const mapRepoFromStorageToUi = (persistedData, persistedLifetimes, dateSt
       mostRecentPrOpenedAtISO8601: repo.pullRequests.mostRecentPrOpenedAt,
       oldestOpenPrOpenedAt,
       oldestOpenPrOpenedAtISO8601: repo.pullRequests.oldestOpenPrOpenedAt,
+      mostRecentBotPrClosedAt,
       mostRecentIssueOpenedAt,
       mostRecentIssueOpenedAtISO8601: repo.issues.mostRecentIssueOpenedAt,
       oldestOpenIssueOpenedAt,

--- a/utils/index.test.js
+++ b/utils/index.test.js
@@ -22,6 +22,7 @@ describe("mapRepoFromStorageToUi", () => {
         pullRequests: {
           mostRecentPrOpenedAt: "2021-01-01T00:00:00Z",
           oldestOpenPrOpenedAt: "2022-02-02T00:00:00Z",
+          mostRecentBotPrClosedAt: "2024-06-06T00:00:00Z",
         },
         issues: {
           openIssues: 0,
@@ -50,6 +51,7 @@ describe("mapRepoFromStorageToUi", () => {
         mostRecentPrOpenedAtISO8601: "2021-01-01T00:00:00Z",
         oldestOpenPrOpenedAt: formatDate("2022-02-02T00:00:00Z"),
         oldestOpenPrOpenedAtISO8601: "2022-02-02T00:00:00Z",
+        mostRecentBotPrClosedAt: formatDate("2024-06-06T00:00:00Z"),
         mostRecentIssueOpenedAt: formatDate("2023-03-03T00:00:00Z"),
         mostRecentIssueOpenedAtISO8601: "2023-03-03T00:00:00Z",
         oldestOpenIssueOpenedAt: formatDate("2024-04-04T00:00:00Z"),
@@ -79,6 +81,7 @@ describe("mapRepoFromStorageToUi", () => {
         pullRequests: {
           mostRecentPrOpenedAt: "2021-01-01T00:00:00Z",
           oldestOpenPrOpenedAt: "2022-02-02T00:00:00Z",
+          mostRecentBotPrClosedAt: null,
         },
         issues: {
           openIssues: 0,
@@ -103,6 +106,7 @@ describe("mapRepoFromStorageToUi", () => {
         pullRequests: {
           mostRecentPrOpenedAt: "2021-01-01T00:00:00Z",
           oldestOpenPrOpenedAt: "2022-02-02T00:00:00Z",
+          mostRecentBotPrClosedAt: null,
         },
         issues: {
           openIssues: 0,
@@ -131,6 +135,7 @@ describe("mapRepoFromStorageToUi", () => {
         mostRecentPrOpenedAtISO8601: "2021-01-01T00:00:00Z",
         oldestOpenPrOpenedAt: formatDate("2022-02-02T00:00:00Z"),
         oldestOpenPrOpenedAtISO8601: "2022-02-02T00:00:00Z",
+        mostRecentBotPrClosedAt: null,
         mostRecentIssueOpenedAt: formatDate("2023-03-03T00:00:00Z"),
         mostRecentIssueOpenedAtISO8601: "2023-03-03T00:00:00Z",
         oldestOpenIssueOpenedAt: formatDate("2024-04-04T00:00:00Z"),
@@ -154,6 +159,7 @@ describe("mapRepoFromStorageToUi", () => {
         mostRecentPrOpenedAtISO8601: "2021-01-01T00:00:00Z",
         oldestOpenPrOpenedAt: formatDate("2022-02-02T00:00:00Z"),
         oldestOpenPrOpenedAtISO8601: "2022-02-02T00:00:00Z",
+        mostRecentBotPrClosedAt: null,
         mostRecentIssueOpenedAt: formatDate("2023-03-03T00:00:00Z"),
         mostRecentIssueOpenedAtISO8601: "2023-03-03T00:00:00Z",
         oldestOpenIssueOpenedAt: formatDate("2024-04-04T00:00:00Z"),
@@ -183,6 +189,7 @@ describe("mapRepoFromStorageToUi", () => {
         pullRequests: {
           mostRecentPrOpenedAt: null,
           oldestOpenPrOpenedAt: null,
+          mostRecentBotPrClosedAt: null,
         },
         issues: {
           openIssues: 0,
@@ -215,6 +222,7 @@ describe("mapRepoFromStorageToUi", () => {
         pullRequests: {
           mostRecentPrOpenedAt: null,
           oldestOpenPrOpenedAt: null,
+          mostRecentBotPrClosedAt: null,
         },
         issues: {
           openIssues: 0,
@@ -247,6 +255,7 @@ describe("mapRepoFromStorageToUi", () => {
         pullRequests: {
           mostRecentPrOpenedAt: "2021-01-01T00:00:00Z",
           oldestOpenPrOpenedAt: "2022-02-02T00:00:00Z",
+          mostRecentBotPrClosedAt: "2024-06-06T00:00:00Z",
         },
         issues: {
           openIssues: 0,
@@ -271,6 +280,7 @@ describe("mapRepoFromStorageToUi", () => {
         pullRequests: {
           mostRecentPrOpenedAt: "2021-01-01T00:00:00Z",
           oldestOpenPrOpenedAt: "2022-02-02T00:00:00Z",
+          mostRecentBotPrClosedAt: "2024-06-06T00:00:00Z",
         },
         issues: {
           openIssues: 0,
@@ -295,6 +305,7 @@ describe("mapRepoFromStorageToUi", () => {
         pullRequests: {
           mostRecentPrOpenedAt: "2021-01-01T00:00:00Z",
           oldestOpenPrOpenedAt: "2022-02-02T00:00:00Z",
+          mostRecentBotPrClosedAt: "2024-06-06T00:00:00Z",
         },
         issues: {
           openIssues: 0,
@@ -333,6 +344,7 @@ describe("mapRepoFromStorageToUi", () => {
         pullRequests: {
           mostRecentPrOpenedAt: null,
           oldestOpenPrOpenedAt: null,
+          mostRecentBotPrClosedAt: null,
         },
         issues: {
           openIssues: 0,
@@ -364,6 +376,7 @@ describe("mapRepoFromStorageToUi", () => {
         pullRequests: {
           mostRecentPrOpenedAt: null,
           oldestOpenPrOpenedAt: null,
+          mostRecentBotPrClosedAt: null,
         },
         issues: {
           openIssues: 0,
@@ -397,6 +410,7 @@ describe("mapRepoFromStorageToUi", () => {
         pullRequests: {
           mostRecentPrOpenedAt: null,
           oldestOpenPrOpenedAt: null,
+          mostRecentBotPrClosedAt: null,
         },
         issues: {
           openIssues: 0,

--- a/webhooks/alerts.js
+++ b/webhooks/alerts.js
@@ -16,8 +16,7 @@ export const handleEvent = async ({ payload, octokit }, db) => {
     repository: payload.repository,
   });
 
-  const repoKey = `${payload.repository.owner.login}/${payload.repository.name}`;
-  db.saveToRepository(repoKey, "dependabotAlerts", alerts);
+  db.saveToRepository(payload.repository.full_name, "dependabotAlerts", alerts);
 };
 
 /**

--- a/webhooks/alerts.js
+++ b/webhooks/alerts.js
@@ -16,7 +16,8 @@ export const handleEvent = async ({ payload, octokit }, db) => {
     repository: payload.repository,
   });
 
-  db.saveToRepository(payload.repository.name, "dependabotAlerts", alerts);
+  const repoKey = `${payload.repository.owner.login}/${payload.repository.name}`;
+  db.saveToRepository(repoKey, "dependabotAlerts", alerts);
 };
 
 /**

--- a/webhooks/alerts.test.js
+++ b/webhooks/alerts.test.js
@@ -53,6 +53,7 @@ describe("handleEvent", () => {
     const payload = {
       repository: {
         name: "repo",
+        full_name: "dxw/repo",
         owner: {
           login: "dxw",
         },
@@ -83,7 +84,7 @@ describe("handleEvent", () => {
     expect.strictEqual(db.saveToRepository.mock.callCount(), 1);
 
     expect.deepStrictEqual(db.saveToRepository.mock.calls[0].arguments, [
-      `${payload.repository.owner.login}/${payload.repository.name}`,
+      payload.repository.full_name,
       "dependabotAlerts",
       expected,
     ]);

--- a/webhooks/alerts.test.js
+++ b/webhooks/alerts.test.js
@@ -83,7 +83,7 @@ describe("handleEvent", () => {
     expect.strictEqual(db.saveToRepository.mock.callCount(), 1);
 
     expect.deepStrictEqual(db.saveToRepository.mock.calls[0].arguments, [
-      payload.repository.name,
+      `${payload.repository.owner.login}/${payload.repository.name}`,
       "dependabotAlerts",
       expected,
     ]);

--- a/webhooks/dependencies.js
+++ b/webhooks/dependencies.js
@@ -22,8 +22,7 @@ export const handleEvent = async ({ payload, octokit }, db, apiClient) => {
     repository: payload.repository,
   });
 
-  const repoKey = `${payload.repository.owner.login}/${payload.repository.name}`;
-  db.saveToRepository(repoKey, "dependencies", dependencies);
+  db.saveToRepository(payload.repository.full_name, "dependencies", dependencies);
 
   const allLifetimes = await fetchAllDependencyLifetimes(db, apiClient);
   await saveAllDependencyLifetimes(allLifetimes, db);

--- a/webhooks/dependencies.js
+++ b/webhooks/dependencies.js
@@ -22,7 +22,8 @@ export const handleEvent = async ({ payload, octokit }, db, apiClient) => {
     repository: payload.repository,
   });
 
-  db.saveToRepository(payload.repository.name, "dependencies", dependencies);
+  const repoKey = `${payload.repository.owner.login}/${payload.repository.name}`;
+  db.saveToRepository(repoKey, "dependencies", dependencies);
 
   const allLifetimes = await fetchAllDependencyLifetimes(db, apiClient);
   await saveAllDependencyLifetimes(allLifetimes, db);

--- a/webhooks/dependencies.test.js
+++ b/webhooks/dependencies.test.js
@@ -79,7 +79,7 @@ describe("handleEvent", () => {
     expect.strictEqual(db.saveToRepository.mock.callCount(), 1);
 
     expect.deepStrictEqual(db.saveToRepository.mock.calls[0].arguments, [
-      payload.repository.name,
+      `${payload.repository.owner.login}/${payload.repository.name}`,
       "dependencies",
       expected,
     ]);

--- a/webhooks/dependencies.test.js
+++ b/webhooks/dependencies.test.js
@@ -39,6 +39,7 @@ describe("handleEvent", () => {
 
     const repository = {
       name: "repo",
+      full_name: "dxw/repo",
       owner: {
         login: "dxw",
       },
@@ -79,7 +80,7 @@ describe("handleEvent", () => {
     expect.strictEqual(db.saveToRepository.mock.callCount(), 1);
 
     expect.deepStrictEqual(db.saveToRepository.mock.calls[0].arguments, [
-      `${payload.repository.owner.login}/${payload.repository.name}`,
+      payload.repository.full_name,
       "dependencies",
       expected,
     ]);
@@ -101,6 +102,7 @@ describe("handleEvent", () => {
 
     const repository = {
       name: "repo",
+      full_name: "dxw/repo",
       owner: {
         login: "dxw",
       },

--- a/webhooks/issues.js
+++ b/webhooks/issues.js
@@ -16,8 +16,7 @@ export const handleEvent = async ({ payload, octokit }, db) => {
     repository: payload.repository,
   });
 
-  const repoKey = `${payload.repository.owner.login}/${payload.repository.name}`;
-  db.saveToRepository(repoKey, "issues", issueInfo);
+  db.saveToRepository(payload.repository.full_name, "issues", issueInfo);
 };
 
 /**

--- a/webhooks/issues.js
+++ b/webhooks/issues.js
@@ -16,7 +16,8 @@ export const handleEvent = async ({ payload, octokit }, db) => {
     repository: payload.repository,
   });
 
-  db.saveToRepository(payload.repository.name, "issues", issueInfo);
+  const repoKey = `${payload.repository.owner.login}/${payload.repository.name}`;
+  db.saveToRepository(repoKey, "issues", issueInfo);
 };
 
 /**

--- a/webhooks/issues.test.js
+++ b/webhooks/issues.test.js
@@ -43,6 +43,7 @@ describe("handleEvent", () => {
     const payload = {
       repository: {
         name: "repo",
+        full_name: "dxw/repo",
         owner: {
           login: "dxw",
         },
@@ -67,7 +68,7 @@ describe("handleEvent", () => {
     expect.strictEqual(db.saveToRepository.mock.callCount(), 1);
 
     expect.deepStrictEqual(db.saveToRepository.mock.calls[0].arguments, [
-      `${payload.repository.owner.login}/${payload.repository.name}`,
+      payload.repository.full_name,
       "issues",
       expected,
     ]);

--- a/webhooks/issues.test.js
+++ b/webhooks/issues.test.js
@@ -67,7 +67,7 @@ describe("handleEvent", () => {
     expect.strictEqual(db.saveToRepository.mock.callCount(), 1);
 
     expect.deepStrictEqual(db.saveToRepository.mock.calls[0].arguments, [
-      payload.repository.name,
+      `${payload.repository.owner.login}/${payload.repository.name}`,
       "issues",
       expected,
     ]);

--- a/webhooks/pullRequests.js
+++ b/webhooks/pullRequests.js
@@ -16,7 +16,8 @@ export const handleEvent = async ({ payload, octokit }, db) => {
     repository: payload.repository,
   });
 
-  db.saveToRepository(payload.repository.name, "pullRequests", prInfo);
+  const repoKey = `${payload.repository.owner.login}/${payload.repository.name}`;
+  db.saveToRepository(repoKey, "pullRequests", prInfo);
 };
 
 /**

--- a/webhooks/pullRequests.js
+++ b/webhooks/pullRequests.js
@@ -16,8 +16,7 @@ export const handleEvent = async ({ payload, octokit }, db) => {
     repository: payload.repository,
   });
 
-  const repoKey = `${payload.repository.owner.login}/${payload.repository.name}`;
-  db.saveToRepository(repoKey, "pullRequests", prInfo);
+  db.saveToRepository(payload.repository.full_name, "pullRequests", prInfo);
 };
 
 /**

--- a/webhooks/pullRequests.test.js
+++ b/webhooks/pullRequests.test.js
@@ -46,6 +46,7 @@ describe("handleEvent", () => {
     const payload = {
       repository: {
         name: "repo",
+        full_name: "dxw/repo",
         owner: {
           login: "dxw",
         },
@@ -73,7 +74,7 @@ describe("handleEvent", () => {
     expect.strictEqual(db.saveToRepository.mock.callCount(), 1);
 
     expect.deepStrictEqual(db.saveToRepository.mock.calls[0].arguments, [
-      `${payload.repository.owner.login}/${payload.repository.name}`,
+      payload.repository.full_name,
       "pullRequests",
       expected,
     ]);

--- a/webhooks/pullRequests.test.js
+++ b/webhooks/pullRequests.test.js
@@ -73,7 +73,7 @@ describe("handleEvent", () => {
     expect.strictEqual(db.saveToRepository.mock.callCount(), 1);
 
     expect.deepStrictEqual(db.saveToRepository.mock.calls[0].arguments, [
-      payload.repository.name,
+      `${payload.repository.owner.login}/${payload.repository.name}`,
       "pullRequests",
       expected,
     ]);

--- a/webhooks/repository.js
+++ b/webhooks/repository.js
@@ -15,8 +15,7 @@ export const handleEvent = async ({ payload }, db) => {
 
   let repo = mapRepoFromApiForStorage(payload.repository);
 
-  const repoKey = `${payload.repository.owner.login}/${payload.repository.name}`;
-  db.saveToRepository(repoKey, "main", repo);
+  db.saveToRepository(payload.repository.full_name, "main", repo);
 };
 
 /**

--- a/webhooks/repository.js
+++ b/webhooks/repository.js
@@ -15,7 +15,8 @@ export const handleEvent = async ({ payload }, db) => {
 
   let repo = mapRepoFromApiForStorage(payload.repository);
 
-  db.saveToRepository(payload.repository.name, "main", repo);
+  const repoKey = `${payload.repository.owner.login}/${payload.repository.name}`;
+  db.saveToRepository(repoKey, "main", repo);
 };
 
 /**

--- a/webhooks/repository.test.js
+++ b/webhooks/repository.test.js
@@ -58,7 +58,7 @@ describe("handleEvent", () => {
     expect.strictEqual(db.saveToRepository.mock.callCount(), 1);
 
     expect.deepStrictEqual(db.saveToRepository.mock.calls[0].arguments, [
-      payload.repository.name,
+      `${payload.repository.owner.login}/${payload.repository.name}`,
       "main",
       expected,
     ]);

--- a/webhooks/repository.test.js
+++ b/webhooks/repository.test.js
@@ -19,6 +19,7 @@ describe("handleEvent", () => {
     const payload = {
       repository: {
         name: "repo",
+        full_name: "dxw/repo",
         description: "Some repo",
         owner: {
           login: "dxw",
@@ -58,7 +59,7 @@ describe("handleEvent", () => {
     expect.strictEqual(db.saveToRepository.mock.callCount(), 1);
 
     expect.deepStrictEqual(db.saveToRepository.mock.calls[0].arguments, [
-      `${payload.repository.owner.login}/${payload.repository.name}`,
+      payload.repository.full_name,
       "main",
       expected,
     ]);


### PR DESCRIPTION
## Summary
- Webhook handlers (alerts, dependencies, issues, pullRequests, repository) were
  building the DB lookup key by manually concatenating owner + repo name, which
  didn't match the `owner/name` key format used by seeded/production data
  (see `utils/githubApi/fetchAllRepos.js`)
- This mismatch meant incoming webhook events (PR/issue/alert/repo changes)
  could silently write to a key that didn't correspond to any existing repo
  record, so live updates from GitHub never reached the UI
- Handlers now use `payload.repository.full_name` directly, which is always
  in the correct `owner/name` format
- Also includes a small formatting fix so `mostRecentBotPrClosedAt` is
  formatted consistently with other date fields
## Test plan
- [x] Unit tests updated for all affected webhook handlers
- [ ] After deploy, redeliver a recent webhook event from the GitHub App
      settings and confirm the corresponding repo record updates correctly
- [ ] Separately verify (outside this PR) that the GitHub App's configured
      webhook URL, secret, and subscribed events match prod env config